### PR TITLE
fix the edge_index in graph_convolution_pyg.py

### DIFF
--- a/src/matgl/layers/_graph_convolution_pyg.py
+++ b/src/matgl/layers/_graph_convolution_pyg.py
@@ -113,7 +113,7 @@ class TensorNetInteraction(nn.Module):
         x_S = traceless_tensors
 
         messages = self.message(edge_index, x_I, x_A, x_S, edge_attr_processed)
-        Im, Am, Sm = self.aggregate(messages, edge_index[1], X.size(0))
+        Im, Am, Sm = self.aggregate(messages, edge_index[0], X.size(0))
         # Combine messages
         msg = Im + Am + Sm
 


### PR DESCRIPTION
## Summary
fix the edge_index in graph_convolution_pyg.py

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
