### PR TITLE
Only update README for hugging face model uploads if the repo doesn't…

### DIFF
--- a/src/matgl/utils/io.py
+++ b/src/matgl/utils/io.py
@@ -204,8 +204,10 @@ class IOMixIn:
 
         The model is saved using the standard matgl serialization (``model.pt``, ``state.pt``
         and ``model.json``) to a temporary directory, then uploaded to the specified
-        repository. A simple ``README.md`` model card is generated if one is not already
-        present in the serialized artifacts.
+        repository. A ``README.md`` model card is generated only when the repository is
+        being created for the first time; if the repository already exists on the Hub, its
+        existing ``README.md`` is left untouched (unless ``readme_text`` is explicitly
+        provided, in which case the supplied content is uploaded).
 
         Args:
             repo_id: Target repository in ``"owner/name"`` form. The repo will be created
@@ -220,12 +222,15 @@ class IOMixIn:
             create_pr: If True, a pull request will be opened instead of committing to
                 the branch directly.
             repo_type: Repo type, typically ``"model"``.
-            readme_text: Optional README.md text to upload.
+            readme_text: Optional README.md text to upload. When provided, the supplied
+                content is always uploaded (overwriting any existing README on the Hub).
+                When omitted, a default README is generated only for newly-created repos.
 
         Returns:
             The URL of the resulting commit on the Hugging Face Hub.
         """
         api = HfApi(token=token)
+        repo_existed = api.repo_exists(repo_id=repo_id, repo_type=repo_type, token=token)
         create_repo(repo_id, private=private, token=token, repo_type=repo_type, exist_ok=True)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -233,7 +238,10 @@ class IOMixIn:
             self.save(tmp_path, metadata=metadata, makedirs=True)  # type: ignore[attr-defined]
 
             readme = tmp_path / "README.md"
-            if not readme.exists():
+            # Only write a README when (a) the user explicitly supplied one, or (b) the
+            # repo is being created fresh. For pre-existing repos with no explicit
+            # readme_text, the existing README on the Hub is retained.
+            if not readme.exists() and (readme_text is not None or not repo_existed):
                 readme.write_text(_generate_hf_model_card(self, metadata=metadata, readme_text=readme_text))
 
             commit = api.upload_folder(

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -175,6 +175,7 @@ def test_push_to_hub_invokes_hub_api(tmp_path):
         patch.object(matgl_io, "HfApi") as fake_api_cls,
     ):
         fake_api = MagicMock()
+        fake_api.repo_exists.return_value = False
         fake_api.upload_folder.side_effect = fake_upload_folder
         fake_api_cls.return_value = fake_api
 
@@ -183,6 +184,51 @@ def test_push_to_hub_invokes_hub_api(tmp_path):
     assert url == "https://huggingface.co/owner/repo/commit/abcdef"
     assert captured["repo_id"] == "owner/repo"
     fake_create.assert_called_once()
+
+
+def test_push_to_hub_retains_existing_readme(tmp_path):
+    """When the repo already exists, push_to_hub must not generate a README."""
+    model = OldModel(2)
+
+    def fake_upload_folder(*, folder_path, repo_id, **kwargs):
+        files = set(os.listdir(folder_path))
+        assert {"model.pt", "state.pt", "model.json"}.issubset(files)
+        assert "README.md" not in files
+        return MagicMock(commit_url="https://huggingface.co/owner/repo/commit/deadbeef")
+
+    with (
+        patch.object(matgl_io, "create_repo"),
+        patch.object(matgl_io, "HfApi") as fake_api_cls,
+    ):
+        fake_api = MagicMock()
+        fake_api.repo_exists.return_value = True
+        fake_api.upload_folder.side_effect = fake_upload_folder
+        fake_api_cls.return_value = fake_api
+
+        model.push_to_hub("owner/repo", metadata={"note": "test"})
+
+
+def test_push_to_hub_uploads_explicit_readme_for_existing_repo(tmp_path):
+    """An explicit ``readme_text`` must be uploaded even when the repo already exists."""
+    model = OldModel(2)
+
+    def fake_upload_folder(*, folder_path, repo_id, **kwargs):
+        files = set(os.listdir(folder_path))
+        assert "README.md" in files
+        contents = (Path(folder_path) / "README.md").read_text()
+        assert "Custom README content" in contents
+        return MagicMock(commit_url="https://huggingface.co/owner/repo/commit/cafebabe")
+
+    with (
+        patch.object(matgl_io, "create_repo"),
+        patch.object(matgl_io, "HfApi") as fake_api_cls,
+    ):
+        fake_api = MagicMock()
+        fake_api.repo_exists.return_value = True
+        fake_api.upload_folder.side_effect = fake_upload_folder
+        fake_api_cls.return_value = fake_api
+
+        model.push_to_hub("owner/repo", readme_text="Custom README content")
 
 
 def test_load_bad_model():


### PR DESCRIPTION
… already exist or a new readme is provided.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
