### PR TITLE
Add PyG support for QET (model + electrostatics) with DGL<->PyG parity tests

### DIFF
--- a/src/matgl/electrostatics/__init__.py
+++ b/src/matgl/electrostatics/__init__.py
@@ -1,1 +1,19 @@
-"""Electrostatics module for MatGL."""
+"""Electrostatics module for MatGL.
+
+Re-exports the active backend's :class:`LinearQeq` charge-equilibration solver
+and :class:`ElectrostaticPotential` aggregator, controlled by
+``matgl.config.BACKEND`` (``"DGL"`` or ``"PYG"``).
+"""
+
+from __future__ import annotations
+
+from matgl.config import BACKEND
+
+if BACKEND == "DGL":
+    from ._elec_pot_dgl import ElectrostaticPotential
+    from ._fast_qeq_dgl import LinearQeq
+else:
+    from ._elec_pot_pyg import ElectrostaticPotential  # type: ignore[assignment]
+    from ._fast_qeq_pyg import LinearQeq  # type: ignore[assignment]
+
+__all__ = ["ElectrostaticPotential", "LinearQeq"]

--- a/src/matgl/electrostatics/_elec_pot_pyg.py
+++ b/src/matgl/electrostatics/_elec_pot_pyg.py
@@ -1,0 +1,85 @@
+"""PyG implementation of the Gaussian-smeared Coulomb electrostatic potential."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+
+import matgl
+from matgl.config import COULOMB_CONSTANT
+from matgl.graph._compute_pyg import compute_pair_vector_and_distance
+from matgl.utils.cutoff import polynomial_cutoff
+from matgl.utils.maths import scatter_add
+
+
+class ElectrostaticPotential(nn.Module):
+    r"""Aggregate per-atom electrostatic potentials over a PyG graph.
+
+    For an edge :math:`i \to j` the contribution to the potential at site
+    :math:`i` is
+
+    .. math::
+
+        V_{ij} = \frac{q_j}{r_{ij}} \,
+                 \mathrm{erf}\!\left(\frac{r_{ij}}{\sqrt{2}\,\gamma_{ij}}\right)
+                 f_\text{cut}(r_{ij}),
+
+    with :math:`\gamma_{ij} = \sqrt{\sigma_i^2 + \sigma_j^2}` the combined
+    Gaussian width, and :math:`f_\text{cut}` a smooth polynomial cutoff. The
+    edge messages are aggregated at the **source** node, matching the DGL
+    implementation in ``matgl.electrostatics._elec_pot_dgl``.
+    """
+
+    def __init__(self, element_types: tuple[str, ...], cutoff: float):
+        """Initialise the electrostatic-potential module.
+
+        Args:
+            element_types: Chemical element symbols in the system. Stored for
+                downstream element-specific extensions; unused in the
+                computation.
+            cutoff: Cutoff radius (Å) beyond which interactions are smoothly
+                damped to zero by ``polynomial_cutoff``.
+        """
+        super().__init__()
+        # Buffers are registered for parity with the DGL module; the actual
+        # computation uses Python-float constants to keep mypy quiet.
+        self.register_buffer("pi", torch.tensor(np.pi, dtype=matgl.float_th))
+        self.register_buffer("sqrt2", torch.tensor(np.sqrt(2), dtype=matgl.float_th))
+        self.element_types = element_types
+        self.cutoff = cutoff
+        self._inv_sqrt2 = 1.0 / math.sqrt(2.0)
+
+    def forward(self, g: Any, charge: torch.Tensor, sigma: torch.Tensor) -> torch.Tensor:
+        """Compute the per-atom electrostatic potential.
+
+        Args:
+            g: PyG ``Data`` / ``Batch``-like object. Must expose ``edge_index``
+                and ``pos``; ``pbc_offshift`` is used if present.
+            charge: Per-atom charges, shape ``(num_nodes,)``.
+            sigma: Per-atom Gaussian widths, shape ``(num_nodes,)``.
+
+        Returns:
+            Per-atom electrostatic potential, shape ``(num_nodes,)``.
+        """
+        if not hasattr(g, "edge_index"):
+            raise AttributeError("ElectrostaticPotential expects a PyG Data-like object with `edge_index`.")
+        if not hasattr(g, "pos"):
+            raise AttributeError("ElectrostaticPotential expects node positions in `pos`.")
+
+        edge_index = g.edge_index
+        src, dst = edge_index[0], edge_index[1]
+
+        _, bond_dist = compute_pair_vector_and_distance(g.pos, edge_index, getattr(g, "pbc_offshift", None))
+        gamma_ij = torch.sqrt(sigma[src] ** 2 + sigma[dst] ** 2)
+        edge_msg = (
+            charge[dst]
+            * torch.erf(bond_dist * self._inv_sqrt2 / gamma_ij)
+            * polynomial_cutoff(bond_dist, self.cutoff)
+            / bond_dist
+        )
+
+        return scatter_add(edge_msg * COULOMB_CONSTANT, src, dim_size=charge.shape[0])

--- a/src/matgl/electrostatics/_fast_qeq_pyg.py
+++ b/src/matgl/electrostatics/_fast_qeq_pyg.py
@@ -1,0 +1,87 @@
+"""PyG implementation of the closed-form charge-equilibration solver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from matgl.utils.maths import scatter_add
+
+
+class LinearQeq(nn.Module):
+    r"""Charge equilibrium within batches of structures (PyG backend).
+
+    Adapted from
+    https://github.com/choderalab/espaloma-charge/blob/main/espaloma_charge/models.py.
+
+    The atomic charges :math:`q_i` are obtained by analytically minimising
+
+    .. math::
+
+        U(\mathbf{q}) = \sum_{i=1}^N \left[ \chi_i q_i + \tfrac12 \, \eta_i q_i^2 \right]
+        - \lambda \left( \sum_{j=1}^N q_j - Q \right)
+
+    using the method of Lagrange multipliers, which yields
+
+    .. math::
+
+        q_i^* = -\chi_i \eta_i^{-1}
+        + \eta_i^{-1} \frac{Q + \sum_j \chi_j \eta_j^{-1}}{\sum_j \eta_j^{-1}}.
+    """
+
+    def forward(
+        self,
+        g: Any,
+        total_charge: torch.Tensor | None,
+        chi: torch.Tensor,
+        hardness: torch.Tensor,
+    ) -> torch.Tensor:
+        """Solve QEq analytically for every graph in a batch.
+
+        Args:
+            g: PyG ``Data`` / ``Batch``-like object. Optional attributes consulted:
+                ``batch`` (per-node graph index), ``num_graphs`` (batch size), and
+                ``q_ref`` (per-node reference charges; if present the per-graph
+                total charge is taken as their sum, overriding ``total_charge``).
+            total_charge: Per-graph total charge. ``None`` is treated as zero;
+                a scalar tensor is broadcast to every graph; otherwise must have
+                one entry per graph in the batch.
+            chi: Per-node electronegativity, shape ``(num_nodes,)``.
+            hardness: Per-node chemical hardness, shape ``(num_nodes,)``.
+
+        Returns:
+            Per-node equilibrated charges, shape ``(num_nodes,)``.
+        """
+        chi = chi.reshape(-1)
+        hardness = hardness.reshape(-1)
+
+        batch = getattr(g, "batch", None)
+        if batch is None:
+            batch = torch.zeros(chi.shape[0], dtype=torch.long, device=chi.device)
+            num_graphs = 1
+        else:
+            batch = batch.to(torch.long)
+            num_graphs = int(getattr(g, "num_graphs", int(batch.max()) + 1))
+
+        hardness_inv = hardness.reciprocal()
+        chi_hardness_inv = chi * hardness_inv
+
+        if hasattr(g, "q_ref"):
+            q_ref = g.q_ref.reshape(-1)
+            total_charge_graph = scatter_add(q_ref, batch, dim_size=num_graphs)
+        elif total_charge is None:
+            total_charge_graph = torch.zeros(num_graphs, device=chi.device, dtype=chi.dtype)
+        else:
+            total_charge_graph = total_charge.to(device=chi.device, dtype=chi.dtype).reshape(-1)
+            if total_charge_graph.numel() == 1:
+                total_charge_graph = total_charge_graph.expand(num_graphs)
+            elif total_charge_graph.numel() != num_graphs:
+                raise ValueError("total_charge must be a scalar or have one value per graph in the batch.")
+
+        sum_hardness_inv = scatter_add(hardness_inv, batch, dim_size=num_graphs)[batch]
+        sum_chi_hardness_inv = scatter_add(chi_hardness_inv, batch, dim_size=num_graphs)[batch]
+        sum_q = total_charge_graph[batch]
+
+        return -chi * hardness_inv + hardness_inv * (sum_q + sum_chi_hardness_inv) / sum_hardness_inv

--- a/src/matgl/models/__init__.py
+++ b/src/matgl/models/__init__.py
@@ -14,6 +14,7 @@ if BACKEND == "DGL":
     from ._so3net import SO3Net
     from ._tensornet_dgl import TensorNet
 else:
+    from ._qet_pyg import QET  # type: ignore[assignment]
     from ._tensornet_pyg import TensorNet  # type: ignore[assignment]
 
 from ._wrappers import TransformedTargetModel

--- a/src/matgl/models/_qet_dgl.py
+++ b/src/matgl/models/_qet_dgl.py
@@ -1,11 +1,11 @@
-"""Implementation of TensorNet model.
+"""Implementation of QET model.
 
-A Cartesian based equivariant GNN model. For more details on TensorNet,
-please refer to::
-
-    G. Simeon, G. de. Fabritiis, _TensorNet: Cartesian Tensor Representations for Efficient Learning of Molecular
-    Potentials. _arXiv, June 10, 2023, 10.48550/arXiv.2306.06482.
-
+QET extends :class:`matgl.models._tensornet_dgl.TensorNet` with per-atom
+electronegativity / hardness / sigma readouts, a closed-form
+charge-equilibration solver (:class:`matgl.electrostatics._fast_qeq_dgl.LinearQeq`)
+and a Gaussian-smeared Coulomb electrostatic potential
+(:class:`matgl.electrostatics._elec_pot_dgl.ElectrostaticPotential`). The
+TensorNet feature extractor is reused via ``forward_features``.
 """
 
 from __future__ import annotations
@@ -22,20 +22,10 @@ import matgl
 from matgl.config import DEFAULT_ELEMENTS
 from matgl.electrostatics._elec_pot_dgl import ElectrostaticPotential
 from matgl.electrostatics._fast_qeq_dgl import LinearQeq
-from matgl.graph._compute_dgl import (
-    compute_pair_vector_and_distance,
-)
-from matgl.layers import (
-    MLP,
-    ActivationFunction,
-    BondExpansion,
-)
-from matgl.layers._embedding_dgl import TensorEmbedding
-from matgl.layers._graph_convolution_dgl import TensorNetInteraction
+from matgl.layers import MLP
 from matgl.layers._readout_dgl import WeightedReadOut
-from matgl.utils.maths import decompose_tensor, tensor_norm
 
-from ._core import MatGLModel
+from ._tensornet_dgl import TensorNet
 
 if TYPE_CHECKING:
     from matgl.graph.converters import GraphConverter
@@ -43,8 +33,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__file__)
 
 
-class QET(MatGLModel):
-    """The main QET model."""
+class QET(TensorNet):
+    """The main QET model.
+
+    A subclass of :class:`TensorNet` that reuses the TensorNet feature
+    extraction stack (bond expansion, tensor embedding, interaction layers,
+    decomposition) and adds a charge-equilibration head that produces
+    per-atom electronegativity, hardness, sigma, equilibrated charges and
+    electrostatic potential, before running an atomic-energy readout over
+    ``[node_feat, charge, elec_pot, magmom?]``.
+    """
 
     __version__ = 1
 
@@ -107,12 +105,13 @@ class QET(MatGLModel):
                (default :obj:`"O(3)"`)
             dtype (torch.dtype): data type for all variables
             width (float): the width of Gaussian radial basis functions
-            readout_type (str): Readout function type, `set2set`, `weighted_atom` (default) or `reduce_atom`.
-            task_type (str): `classification` or `regression` (default).
-            niters_set2set (int): Number of set2set iterations
-            nlayers_set2set (int): Number of set2set layers
-            field (str): Using either "node_feat" or "edge_feat" for Set2Set and Reduced readout
-            is_intensive (bool): Whether the prediction is intensive
+            readout_type (str): Accepted for IOMixIn compatibility; QET always uses an
+                atomic-energy ``WeightedReadOut`` over the concatenated node features.
+            task_type (str): Accepted for IOMixIn compatibility; QET is always regression.
+            niters_set2set (int): Accepted for IOMixIn compatibility; unused by QET.
+            nlayers_set2set (int): Accepted for IOMixIn compatibility; unused by QET.
+            field (str): Accepted for IOMixIn compatibility; unused by QET.
+            is_intensive (bool): Accepted for IOMixIn compatibility; QET is always extensive.
             ntargets (int): Number of target properties
             include_magmom (bool): Whether the magmom is returned (not implemented yet)
             is_hardness_envs (bool): Whether the hardness is environment dependent
@@ -121,88 +120,60 @@ class QET(MatGLModel):
             **kwargs: For future flexibility. Not used at the moment.
 
         """
-        super().__init__()
-
-        self.save_args(locals(), kwargs)
-
-        try:
-            activation: nn.Module = ActivationFunction[activation_type].value()
-        except KeyError:
-            raise ValueError(
-                f"Invalid activation type, please try using one of {[af.name for af in ActivationFunction]}"
-            ) from None
-
-        if element_types is None:
-            self.element_types = DEFAULT_ELEMENTS
-        else:
-            self.element_types = element_types  # type: ignore
-
-        self.bond_expansion = BondExpansion(
-            cutoff=cutoff,
-            rbf_type=rbf_type,
-            final=cutoff + 1.0,
-            num_centers=num_rbf,
-            width=width,
-            smooth=use_smooth,
-            max_n=max_n,
-            max_l=max_l,
-        )
-
-        assert equivariance_invariance_group in ["O(3)", "SO(3)"], "Unknown group representation. Choose O(3) or SO(3)."
-
-        self.units = units
-        self.equivariance_invariance_group = equivariance_invariance_group
-        self.num_layers = nblocks
-        self.num_rbf = num_rbf
-        self.rbf_type = rbf_type
-        self.activation = activation
-        self.cutoff = cutoff
-        self.dim_state_embedding = dim_state_embedding
-        self.dim_state_feats = dim_state_feats
-        self.include_state = include_state
-        self.ntypes_state = ntypes_state
-        self.task_type = task_type
-
-        # make sure the number of radial basis functions correct for tensor embedding
-        if rbf_type == "SphericalBessel":
-            num_rbf = max_n
-
-        self.tensor_embedding = TensorEmbedding(
+        # Defer reset_parameters until after QET-specific heads are built so the
+        # random init stream order matches the pre-subclass implementation
+        # (otherwise the parent's reset would shift the stream and break
+        # existing checkpoints / regression tests).
+        self._qet_init_complete = False
+        # QET reuses TensorNet feature extraction. is_intensive/task_type/readout_type
+        # are forced to the QET-specific path; the user-facing signature preserves the
+        # other args verbatim so existing model.json files round-trip via IOMixIn.
+        super().__init__(
+            element_types=element_types,
             units=units,
-            degree_rbf=num_rbf,
+            ntypes_state=ntypes_state,
             dim_state_embedding=dim_state_embedding,
             dim_state_feats=dim_state_feats,
-            ntypes_state=ntypes_state,
             include_state=include_state,
-            activation=activation,
-            ntypes_node=len(element_types),
+            nblocks=nblocks,
+            num_rbf=num_rbf,
+            max_n=max_n,
+            max_l=max_l,
+            rbf_type=rbf_type,
+            use_smooth=use_smooth,
+            activation_type=activation_type,
             cutoff=cutoff,
+            equivariance_invariance_group=equivariance_invariance_group,
             dtype=dtype,
+            width=width,
+            readout_type="weighted_atom",
+            task_type="regression",
+            niters_set2set=niters_set2set,
+            nlayers_set2set=nlayers_set2set,
+            field=field,
+            is_intensive=False,
+            ntargets=ntargets,
+            **kwargs,
         )
+        # Re-record the user-facing constructor args so IOMixIn round-trips QET, not TensorNet.
+        self.save_args(locals(), kwargs)
 
-        self.layers = nn.ModuleList(
-            {
-                TensorNetInteraction(num_rbf, units, activation, cutoff, equivariance_invariance_group, dtype)
-                for _ in range(nblocks)
-                if nblocks != 0
-            }
-        )
+        self.is_hardness_envs = is_hardness_envs
+        self.include_magmom = include_magmom
+        self.return_features = return_features
 
-        self.out_norm = nn.LayerNorm(3 * units, dtype=dtype)
-        self.linear = nn.Linear(3 * units, units, dtype=dtype)
-        # check whether hardness is environment dependent property
         self.hardness_readout: nn.Parameter | nn.Module
-        if is_hardness_envs is False:
-            hardness = torch.ones(len(element_types))
-            self.hardness_readout = torch.nn.Parameter(data=hardness)
+        if not is_hardness_envs:
+            self.hardness_readout = torch.nn.Parameter(data=torch.ones(len(element_types)))
         else:
             self.hardness_readout = MLP(dims=[units, units, units, 1], activation=nn.Softplus(), activate_last=True)
+
         if is_sigma_train:
-            sigma = torch.ones(len(element_types))
-            self.sigma = torch.nn.Parameter(data=sigma)
+            self.sigma = torch.nn.Parameter(data=torch.ones(len(element_types)))
         else:
             self.register_buffer(
-                "sigma", torch.tensor([covalent_radii[atomic_numbers[i]] for i in element_types], dtype=matgl.float_th)
+                "sigma",
+                torch.tensor([covalent_radii[atomic_numbers[i]] for i in element_types], dtype=matgl.float_th),
             )
 
         self.chi_readout = MLP(dims=[units, units, units, 1], activation=nn.SiLU(), activate_last=True)
@@ -211,28 +182,43 @@ class QET(MatGLModel):
                 dims=[units, units, units, 1], activation=nn.SiLU(), activate_last=False, bias_last=False
             )
 
-        self.is_hardness_envs = is_hardness_envs
-
         self.qeq = LinearQeq()
         self.elec_pot = ElectrostaticPotential(element_types=element_types, cutoff=cutoff)
         self.norm = nn.LayerNorm(units + 3) if include_magmom else nn.LayerNorm(units + 2)
-        # short-range energy
+        # QET reads atomic energies from the wider concatenated node_feat.
         self.final_layer = WeightedReadOut(
-            in_feats=(units + 3 if include_magmom else units + 2),  # 1 for atomic charge, 1  for elec_pot, 1 for magmom
+            in_feats=(units + 3 if include_magmom else units + 2),  # +1 charge, +1 elec_pot, (+1 magmom)
             dims=[units, units],
             num_targets=ntargets,  # type: ignore
         )
-        self.include_magmom = include_magmom
-        self.return_features = return_features
+
+        # All heads built; now do the deferred reset_parameters at the same
+        # point in the random stream as the original non-subclassed QET.
+        self._qet_init_complete = True
         self.reset_parameters()
 
-    def reset_parameters(self):
-        self.tensor_embedding.reset_parameters()
-        for layer in self.layers:
-            layer.reset_parameters()
-        self.out_norm.reset_parameters()
+    def _build_readout(self, *args, **kwargs) -> None:
+        """Skip the parent's readout build; QET constructs its own ``final_layer``
+        in :meth:`__init__` over the wider concatenated feature. Suppressing the
+        parent build also keeps the random init order identical to the original
+        non-subclassed QET, so saved checkpoints / regression tests still match.
+        """
+        return
 
-    def forward(
+    def reset_parameters(self) -> None:
+        """Reset trainable parameters of the inherited TensorNet stack.
+
+        While ``self._qet_init_complete`` is ``False`` (i.e. QET is still inside
+        its own ``__init__``), this is a no-op so that the parent's automatic
+        ``reset_parameters()`` call inside ``super().__init__`` does not perturb
+        the random stream. QET re-invokes this method at the end of its own
+        ``__init__`` once all heads have been built.
+        """
+        if not getattr(self, "_qet_init_complete", False):
+            return
+        super().reset_parameters()
+
+    def forward(  # type: ignore[override]
         self,
         g: dgl.DGLGraph,
         total_charge: torch.Tensor | None = None,
@@ -250,41 +236,22 @@ class QET(MatGLModel):
             **kwargs: For future flexibility. Not used at the moment.
 
         Returns:
-            output: output: Output property for a batch of graphs
+            output: Output property for a batch of graphs
         """
         if ext_pot is not None:
-            chi_ext = ext_pot
-            g.ndata["chi_ext"] = chi_ext
-        # Obtain graph, with distances and relative position vectors
-        bond_vec, bond_dist = compute_pair_vector_and_distance(g)
-        g.edata["bond_vec"] = bond_vec.to(g.device)
-        g.edata["bond_dist"] = bond_dist.to(g.device)
+            g.ndata["chi_ext"] = ext_pot
 
-        # This asserts convinces TorchScript that edge_vec is a Tensor and not an Optional[Tensor]
-
-        # Expand distances with radial basis functions
-        edge_attr = self.bond_expansion(g.edata["bond_dist"])
-        g.edata["edge_attr"] = edge_attr
-
-        # Embedding from edge-wise tensors to node-wise tensors
-        X, _, _ = self.tensor_embedding(g, state_attr)
-        # Interaction layers
-        for layer in self.layers:
-            X = layer(g, X)
-        scalars, skew_metrices, traceless_tensors = decompose_tensor(X)
-
-        x = torch.cat((tensor_norm(scalars), tensor_norm(skew_metrices), tensor_norm(traceless_tensors)), dim=-1)
-        x = self.out_norm(x)
-        x = self.linear(x)
+        fea_dict = self.forward_features(g=g, state_attr=state_attr)
+        x = fea_dict["readout"]
 
         g.ndata["chi"] = (
             torch.squeeze(self.chi_readout(x)) + g.ndata["chi_ext"]
             if "chi_ext" in g.ndata
             else torch.squeeze(self.chi_readout(x))
-        )  # (num_nodes, 1)
+        )
 
         if self.include_magmom:
-            g.ndata["magmom"] = torch.squeeze(self.magmom_readout(x))  # (num_nodes, 1)
+            g.ndata["magmom"] = torch.squeeze(self.magmom_readout(x))
 
         if self.is_hardness_envs:
             g.ndata["hardness"] = torch.squeeze(self.hardness_readout(x))  # type: ignore[operator]
@@ -295,6 +262,7 @@ class QET(MatGLModel):
 
         g = self.qeq(g=g, total_charge=total_charge)
         g = self.elec_pot(g)
+
         combined_node_feat = (
             torch.hstack(
                 [
@@ -309,12 +277,13 @@ class QET(MatGLModel):
         )
         g.ndata["node_feat"] = self.norm(combined_node_feat)
         g.ndata["atomic_energy"] = self.final_layer(g)
+
         if self.return_features:
             return g.ndata["node_feat"], g.ndata["atomic_energy"]
-        e_total = dgl.readout_nodes(g, "atomic_energy", op="sum")
-        return torch.squeeze(e_total)
 
-    def predict_structure(
+        return torch.squeeze(dgl.readout_nodes(g, "atomic_energy", op="sum"))
+
+    def predict_structure(  # type: ignore[override]
         self,
         structure,
         state_feats: torch.Tensor | None = None,

--- a/src/matgl/models/_qet_pyg.py
+++ b/src/matgl/models/_qet_pyg.py
@@ -66,10 +66,6 @@ class QET(TensorNet):
         equivariance_invariance_group: str = "O(3)",
         dtype: torch.dtype = matgl.float_th,
         width: float = 0.5,
-        readout_type: Literal["weighted_atom", "reduce_atom"] = "weighted_atom",
-        task_type: Literal["classification", "regression"] = "regression",
-        field: Literal["node_feat", "edge_feat"] = "node_feat",
-        is_intensive: bool = True,
         ntargets: int = 1,
         is_sigma_train: bool = False,
         is_hardness_envs: bool = False,
@@ -105,11 +101,6 @@ class QET(TensorNet):
                (default :obj:`"O(3)"`)
             dtype (torch.dtype): data type for all variables
             width (float): the width of Gaussian radial basis functions
-            readout_type (str): Accepted for IOMixIn compatibility; QET always uses an
-                atomic-energy ``WeightedReadOut`` over the concatenated node features.
-            task_type (str): Accepted for IOMixIn compatibility; QET is always regression.
-            field (str): Accepted for IOMixIn compatibility; unused by QET.
-            is_intensive (bool): Accepted for IOMixIn compatibility; QET is always extensive.
             ntargets (int): Number of target properties
             include_magmom (bool): Whether the magmom is returned (not implemented yet)
             is_hardness_envs (bool): Whether the hardness is environment dependent
@@ -120,9 +111,12 @@ class QET(TensorNet):
             **kwargs: For future flexibility. Not used at the moment.
 
         """
-        # Defer reset_parameters until after QET-specific heads are built so the
-        # random init stream order matches the standalone implementation.
-        self._qet_init_complete = False
+        # QET ignores intensive / readout-shape kwargs — it is always extensive
+        # and always applies a WeightedReadOut over the wider concatenated
+        # node feature. Silently drop them so callers / saved checkpoints that
+        # pass them through don't crash on duplicate kwargs.
+        for legacy in ("is_intensive", "readout_type", "task_type", "field"):
+            kwargs.pop(legacy, None)
         super().__init__(
             element_types=element_types,
             units=units,
@@ -141,9 +135,6 @@ class QET(TensorNet):
             equivariance_invariance_group=equivariance_invariance_group,
             dtype=dtype,
             width=width,
-            readout_type="weighted_atom",
-            task_type="regression",
-            field=field,
             is_intensive=False,
             ntargets=ntargets,
             use_warp=use_warp,
@@ -156,14 +147,14 @@ class QET(TensorNet):
         self.include_magmom = include_magmom
         self.return_features = return_features
 
-        self.hardness_readout: nn.Parameter | nn.Module
-        if not is_hardness_envs:
-            self.hardness_readout = torch.nn.Parameter(data=torch.ones(len(element_types)))
-        else:
-            self.hardness_readout = MLP(dims=[units, units, units, 1], activation=nn.Softplus(), activate_last=True)
+        self.hardness_readout: nn.Module | nn.Parameter = (
+            MLP(dims=[units, units, units, 1], activation=nn.Softplus(), activate_last=True)
+            if is_hardness_envs
+            else nn.Parameter(torch.ones(len(element_types)))
+        )
 
         if is_sigma_train:
-            self.sigma = torch.nn.Parameter(data=torch.ones(len(element_types)))
+            self.sigma = nn.Parameter(torch.ones(len(element_types)))
         else:
             self.register_buffer(
                 "sigma",
@@ -178,34 +169,12 @@ class QET(TensorNet):
 
         self.qeq = LinearQeq()
         self.elec_pot = ElectrostaticPotential(element_types=element_types, cutoff=cutoff)
-        self.norm = nn.LayerNorm(units + 3) if include_magmom else nn.LayerNorm(units + 2)
-        self.final_layer = WeightedReadOut(
-            in_feats=(units + 3 if include_magmom else units + 2),  # +1 charge, +1 elec_pot, (+1 magmom)
-            dims=[units, units],
-            num_targets=ntargets,  # type: ignore
+        extra_feats = 3 if include_magmom else 2  # +1 charge, +1 elec_pot, (+1 magmom)
+        self.norm = nn.LayerNorm(units + extra_feats)
+        # Replaces the parent's WeightedReadOut, which is built over the narrower units-wide feature.
+        self.final_layer = WeightedReadOut(  # type: ignore[assignment]
+            in_feats=units + extra_feats, dims=[units, units], num_targets=ntargets
         )
-
-        self._qet_init_complete = True
-        self.reset_parameters()
-
-    def _build_readout(self, *args, **kwargs) -> None:
-        """Skip the parent's readout build; QET constructs its own ``final_layer``
-        in :meth:`__init__` over the wider concatenated feature.
-        """
-        return
-
-    def reset_parameters(self) -> None:
-        """Reset trainable parameters of the inherited TensorNet stack.
-
-        While ``self._qet_init_complete`` is ``False`` (i.e. QET is still inside
-        its own ``__init__``), this is a no-op so that the parent's automatic
-        ``reset_parameters()`` call inside ``super().__init__`` does not perturb
-        the random stream. QET re-invokes this method at the end of its own
-        ``__init__`` once all heads have been built.
-        """
-        if not getattr(self, "_qet_init_complete", False):
-            return
-        super().reset_parameters()
 
     def forward(  # type: ignore[override]
         self,
@@ -263,20 +232,13 @@ class QET(TensorNet):
             return node_feat, atomic_energies
 
         batch = getattr(g, "batch", None)
-        num_graphs = getattr(g, "num_graphs", None)
-        if batch is not None:
-            if atomic_energies.shape == (1, 1):
-                atomic_energies = atomic_energies.squeeze(-1)
-            else:
-                atomic_energies = atomic_energies.squeeze()
-            batch_long = batch.to(torch.long)
-            if num_graphs is None:
-                num_graphs = int(batch_long.max()) + 1
-            e_total = scatter_add(atomic_energies, batch_long, dim_size=num_graphs)
+        if batch is None:
+            batch = atomic_energies.new_zeros(atomic_energies.shape[0], dtype=torch.long)
+            num_graphs = 1
         else:
-            e_total = torch.sum(atomic_energies, dim=0, keepdim=True).squeeze()
-
-        return torch.squeeze(e_total)
+            batch = batch.to(torch.long)
+            num_graphs = int(getattr(g, "num_graphs", int(batch.max()) + 1))
+        return torch.squeeze(scatter_add(atomic_energies.squeeze(-1), batch, dim_size=num_graphs))
 
     def predict_structure(  # type: ignore[override]
         self,

--- a/src/matgl/models/_qet_pyg.py
+++ b/src/matgl/models/_qet_pyg.py
@@ -1,0 +1,311 @@
+"""PyG implementation of the QET model.
+
+QET extends :class:`matgl.models._tensornet_pyg.TensorNet` (PyG) with
+per-atom electronegativity / hardness / sigma readouts, a closed-form
+charge-equilibration solver
+(:class:`matgl.electrostatics._fast_qeq_pyg.LinearQeq`) and a
+Gaussian-smeared Coulomb electrostatic potential
+(:class:`matgl.electrostatics._elec_pot_pyg.ElectrostaticPotential`). The
+TensorNet feature extractor is reused via ``forward_features``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+import torch
+from ase.data import atomic_numbers, covalent_radii
+from torch import nn
+
+import matgl
+from matgl.config import DEFAULT_ELEMENTS
+from matgl.electrostatics._elec_pot_pyg import ElectrostaticPotential
+from matgl.electrostatics._fast_qeq_pyg import LinearQeq
+from matgl.layers import MLP
+from matgl.layers._readout_torch import WeightedReadOut
+from matgl.utils.maths import scatter_add
+
+from ._tensornet_pyg import TensorNet
+
+if TYPE_CHECKING:
+    from matgl.graph._converters_pyg import GraphConverter
+
+logger = logging.getLogger(__file__)
+
+
+class QET(TensorNet):
+    """The main QET model (PyG backend).
+
+    A subclass of :class:`TensorNet` (PyG) that reuses the TensorNet feature
+    extraction stack (bond expansion, tensor embedding, interaction layers,
+    decomposition) and adds a charge-equilibration head producing per-atom
+    electronegativity, hardness, sigma, equilibrated charges and electrostatic
+    potential, before running an atomic-energy readout over
+    ``[node_feat, charge, elec_pot, magmom?]``.
+    """
+
+    __version__ = 1
+
+    def __init__(
+        self,
+        element_types: tuple[str, ...] = DEFAULT_ELEMENTS,
+        units: int = 64,
+        ntypes_state: int | None = None,
+        dim_state_embedding: int = 0,
+        dim_state_feats: int | None = None,
+        include_state: bool = False,
+        nblocks: int = 2,
+        num_rbf: int = 32,
+        max_n: int = 3,
+        max_l: int = 3,
+        rbf_type: Literal["Gaussian", "SphericalBessel"] = "Gaussian",
+        use_smooth: bool = False,
+        activation_type: Literal["swish", "tanh", "sigmoid", "softplus2", "softexp"] = "swish",
+        cutoff: float = 5.0,
+        equivariance_invariance_group: str = "O(3)",
+        dtype: torch.dtype = matgl.float_th,
+        width: float = 0.5,
+        readout_type: Literal["weighted_atom", "reduce_atom"] = "weighted_atom",
+        task_type: Literal["classification", "regression"] = "regression",
+        field: Literal["node_feat", "edge_feat"] = "node_feat",
+        is_intensive: bool = True,
+        ntargets: int = 1,
+        is_sigma_train: bool = False,
+        is_hardness_envs: bool = False,
+        include_magmom: bool = False,
+        return_features: bool = False,
+        use_warp: bool | None = None,
+        **kwargs,
+    ):
+        r"""
+
+        Args:
+            element_types (tuple): List of elements appearing in the dataset. Default to DEFAULT_ELEMENTS.
+            units (int, optional): Hidden embedding size.
+                (default: :obj:`64`)
+            ntypes_state (int): Number of state labels
+            dim_state_embedding (int): Number of hidden neurons in state embedding
+            dim_state_feats (int): Number of state features after linear layer
+            include_state (bool): Whether to include states features
+            nblocks (int, optional): The number of interaction layers.
+                (default: :obj:`2`)
+            num_rbf (int, optional): The number of radial basis Gaussian functions :math:`\mu`.
+                (default: :obj:`32`)
+            max_n (int): maximum of n in spherical Bessel functions
+            max_l (int): maximum of l in spherical Bessel functions
+            rbf_type (str): Radial basis function. choose from 'Gaussian' or 'SphericalBessel'
+            use_smooth (bool): Whether to use the smooth version of SphericalBessel functions.
+                This is particularly important for the smoothness of PES.
+            activation_type (str): Activation type. choose from 'swish', 'tanh', 'sigmoid', 'softplus2', 'softexp'
+            cutoff (float): cutoff distance for interatomic interactions.
+            equivariance_invariance_group (string, optional): Group under whose action on input
+                positions internal tensor features will be equivariant and scalar predictions
+                will be invariant. O(3) or SO(3).
+               (default :obj:`"O(3)"`)
+            dtype (torch.dtype): data type for all variables
+            width (float): the width of Gaussian radial basis functions
+            readout_type (str): Accepted for IOMixIn compatibility; QET always uses an
+                atomic-energy ``WeightedReadOut`` over the concatenated node features.
+            task_type (str): Accepted for IOMixIn compatibility; QET is always regression.
+            field (str): Accepted for IOMixIn compatibility; unused by QET.
+            is_intensive (bool): Accepted for IOMixIn compatibility; QET is always extensive.
+            ntargets (int): Number of target properties
+            include_magmom (bool): Whether the magmom is returned (not implemented yet)
+            is_hardness_envs (bool): Whether the hardness is environment dependent
+            is_sigma_train (bool): Whether the sigma is trainable
+            return_features (bool): Whether the atomic features are returned
+            use_warp (bool | None): Whether to use warp-accelerated kernels from ``nvalchemi-toolkit-ops``.
+                Same semantics as :class:`TensorNet`.
+            **kwargs: For future flexibility. Not used at the moment.
+
+        """
+        # Defer reset_parameters until after QET-specific heads are built so the
+        # random init stream order matches the standalone implementation.
+        self._qet_init_complete = False
+        super().__init__(
+            element_types=element_types,
+            units=units,
+            ntypes_state=ntypes_state,
+            dim_state_embedding=dim_state_embedding,
+            dim_state_feats=dim_state_feats,
+            include_state=include_state,
+            nblocks=nblocks,
+            num_rbf=num_rbf,
+            max_n=max_n,
+            max_l=max_l,
+            rbf_type=rbf_type,
+            use_smooth=use_smooth,
+            activation_type=activation_type,
+            cutoff=cutoff,
+            equivariance_invariance_group=equivariance_invariance_group,
+            dtype=dtype,
+            width=width,
+            readout_type="weighted_atom",
+            task_type="regression",
+            field=field,
+            is_intensive=False,
+            ntargets=ntargets,
+            use_warp=use_warp,
+            **kwargs,
+        )
+        # Re-record the user-facing args so IOMixIn round-trips QET, not TensorNet.
+        self.save_args(locals(), kwargs)
+
+        self.is_hardness_envs = is_hardness_envs
+        self.include_magmom = include_magmom
+        self.return_features = return_features
+
+        self.hardness_readout: nn.Parameter | nn.Module
+        if not is_hardness_envs:
+            self.hardness_readout = torch.nn.Parameter(data=torch.ones(len(element_types)))
+        else:
+            self.hardness_readout = MLP(dims=[units, units, units, 1], activation=nn.Softplus(), activate_last=True)
+
+        if is_sigma_train:
+            self.sigma = torch.nn.Parameter(data=torch.ones(len(element_types)))
+        else:
+            self.register_buffer(
+                "sigma",
+                torch.tensor([covalent_radii[atomic_numbers[i]] for i in element_types], dtype=matgl.float_th),
+            )
+
+        self.chi_readout = MLP(dims=[units, units, units, 1], activation=nn.SiLU(), activate_last=True)
+        if include_magmom:
+            self.magmom_readout = MLP(
+                dims=[units, units, units, 1], activation=nn.SiLU(), activate_last=False, bias_last=False
+            )
+
+        self.qeq = LinearQeq()
+        self.elec_pot = ElectrostaticPotential(element_types=element_types, cutoff=cutoff)
+        self.norm = nn.LayerNorm(units + 3) if include_magmom else nn.LayerNorm(units + 2)
+        self.final_layer = WeightedReadOut(
+            in_feats=(units + 3 if include_magmom else units + 2),  # +1 charge, +1 elec_pot, (+1 magmom)
+            dims=[units, units],
+            num_targets=ntargets,  # type: ignore
+        )
+
+        self._qet_init_complete = True
+        self.reset_parameters()
+
+    def _build_readout(self, *args, **kwargs) -> None:
+        """Skip the parent's readout build; QET constructs its own ``final_layer``
+        in :meth:`__init__` over the wider concatenated feature.
+        """
+        return
+
+    def reset_parameters(self) -> None:
+        """Reset trainable parameters of the inherited TensorNet stack.
+
+        While ``self._qet_init_complete`` is ``False`` (i.e. QET is still inside
+        its own ``__init__``), this is a no-op so that the parent's automatic
+        ``reset_parameters()`` call inside ``super().__init__`` does not perturb
+        the random stream. QET re-invokes this method at the end of its own
+        ``__init__`` once all heads have been built.
+        """
+        if not getattr(self, "_qet_init_complete", False):
+            return
+        super().reset_parameters()
+
+    def forward(  # type: ignore[override]
+        self,
+        g: Any,
+        total_charge: torch.Tensor | None = None,
+        state_attr: torch.Tensor | None = None,
+        ext_pot: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        """
+
+        Args:
+            g: PyG ``Data`` / ``Batch``-like object with ``node_type`` (or ``z``),
+                ``pos``, ``edge_index``, and optionally ``pbc_offshift``,
+                ``batch``, ``num_graphs``.
+            total_charge: total charge for a batch of graphs.
+            state_attr: State attrs for a batch of graphs.
+            ext_pot: External potential, broadcastable to per-node.
+            **kwargs: For future flexibility. Not used at the moment.
+
+        Returns:
+            Per-graph total energy (or ``(node_feat, atomic_energies)`` when
+            ``return_features=True``).
+        """
+        fea_dict = self.forward_features(g, state_attr)
+        x = fea_dict["readout"]
+
+        chi = torch.squeeze(self.chi_readout(x))
+        if ext_pot is not None:
+            chi = chi + ext_pot
+
+        node_type = getattr(g, "node_type", getattr(g, "z", None))
+        if node_type is None:
+            raise AttributeError("QET expects `node_type` or `z` on the input graph.")
+        node_type = node_type.to(torch.long)
+
+        if self.is_hardness_envs:
+            hardness = torch.squeeze(self.hardness_readout(x))  # type: ignore[operator]
+        else:
+            hardness = torch.squeeze(self.hardness_readout[node_type])  # type: ignore[index]
+
+        sigma = torch.squeeze(self.sigma[node_type])
+
+        charge = self.qeq(g=g, total_charge=total_charge, chi=chi, hardness=hardness)
+        elec_pot = self.elec_pot(g, charge=charge, sigma=sigma)
+
+        feats = [x, charge.unsqueeze(dim=1), elec_pot.unsqueeze(dim=1)]
+        if self.include_magmom:
+            magmom = torch.squeeze(self.magmom_readout(x))
+            feats.append(magmom.unsqueeze(dim=1))
+        node_feat = self.norm(torch.hstack(feats))
+        atomic_energies = self.final_layer(node_feat)
+
+        if self.return_features:
+            return node_feat, atomic_energies
+
+        batch = getattr(g, "batch", None)
+        num_graphs = getattr(g, "num_graphs", None)
+        if batch is not None:
+            if atomic_energies.shape == (1, 1):
+                atomic_energies = atomic_energies.squeeze(-1)
+            else:
+                atomic_energies = atomic_energies.squeeze()
+            batch_long = batch.to(torch.long)
+            if num_graphs is None:
+                num_graphs = int(batch_long.max()) + 1
+            e_total = scatter_add(atomic_energies, batch_long, dim_size=num_graphs)
+        else:
+            e_total = torch.sum(atomic_energies, dim=0, keepdim=True).squeeze()
+
+        return torch.squeeze(e_total)
+
+    def predict_structure(  # type: ignore[override]
+        self,
+        structure,
+        state_feats: torch.Tensor | None = None,
+        total_charge: torch.Tensor | None = None,
+        graph_converter: GraphConverter | None = None,
+    ):
+        """Convenience method to directly predict a property from a structure.
+
+        Args:
+            structure: An input crystal/molecule.
+            state_feats: Graph attributes
+            total_charge: Total charge of the structure
+            graph_converter: Object that implements ``get_graph``.
+
+        Returns:
+            output (torch.Tensor): output property
+        """
+        if graph_converter is None:
+            from matgl.ext._pymatgen_pyg import Structure2Graph
+
+            graph_converter = Structure2Graph(element_types=self.element_types, cutoff=self.cutoff)  # type: ignore
+        g, lat, state_feats_default = graph_converter.get_graph(structure)
+        g.pbc_offshift = torch.matmul(g.pbc_offset, lat[0])
+        g.pos = g.frac_coords @ lat[0]
+        if state_feats is None:
+            state_feats = torch.tensor(state_feats_default)
+        if self.return_features:
+            node_features, atomic_energies = self(g=g, state_attr=state_feats, total_charge=total_charge)
+            return node_features.detach(), atomic_energies.detach()
+        return self(g=g, state_attr=state_feats, total_charge=total_charge).detach()

--- a/src/matgl/models/_tensornet_dgl.py
+++ b/src/matgl/models/_tensornet_dgl.py
@@ -179,7 +179,39 @@ class TensorNet(MatGLModel):
 
         self.out_norm = nn.LayerNorm(3 * units, dtype=dtype)
         self.linear = nn.Linear(3 * units, units, dtype=dtype)
-        if is_intensive:
+        self.is_intensive = is_intensive
+        self._build_readout(
+            units=units,
+            ntargets=ntargets,
+            readout_type=readout_type,
+            niters_set2set=niters_set2set,
+            nlayers_set2set=nlayers_set2set,
+            field=field,
+            include_state=include_state,
+            dim_state_feats=dim_state_feats,
+            activation=activation,
+            task_type=task_type,
+        )
+        self.reset_parameters()
+
+    def _build_readout(
+        self,
+        units: int,
+        ntargets: int,
+        readout_type: Literal["set2set", "weighted_atom", "reduce_atom"],
+        niters_set2set: int,
+        nlayers_set2set: int,
+        field: Literal["node_feat", "edge_feat"],
+        include_state: bool,
+        dim_state_feats: int | None,
+        activation: nn.Module,
+        task_type: Literal["classification", "regression"],
+    ) -> None:
+        """Build the readout / ``final_layer`` modules. Override in a subclass to
+        skip or replace the default readout construction (e.g. ``QET`` builds its
+        own atomic-energy head over a wider concatenated node feature).
+        """
+        if self.is_intensive:
             input_feats = units
             self.readout: nn.Module
             if readout_type == "set2set":
@@ -198,7 +230,6 @@ class TensorNet(MatGLModel):
             self.final_layer = MLP(dims_final_layer, activation, activate_last=False)
             if task_type == "classification":
                 self.sigmoid = nn.Sigmoid()
-
         else:
             if task_type == "classification":
                 raise ValueError("Classification task cannot be extensive.")
@@ -208,32 +239,29 @@ class TensorNet(MatGLModel):
                 num_targets=ntargets,  # type: ignore
             )
 
-        self.is_intensive = is_intensive
-        self.reset_parameters()
-
     def reset_parameters(self):
         self.tensor_embedding.reset_parameters()
         for layer in self.layers:
             layer.reset_parameters()
         self.out_norm.reset_parameters()
 
-    def forward(
+    def forward_features(
         self,
         g: dgl.DGLGraph,
         state_attr: torch.Tensor | None = None,
-        return_all_layer_output: bool = False,
         **kwargs,
-    ):
-        """
+    ) -> dict:
+        """Run TensorNet's feature extraction up through the per-atom readout.
+
+        Returns a dict with intermediate features (``edge_attr``, ``embedding``,
+        ``gc_<i>``, ``readout``) and writes the final per-atom features to
+        ``g.ndata["node_feat"]``. Subclasses (e.g. ``QET``) reuse this without
+        re-implementing the embedding / interaction stack.
 
         Args:
-            g : DGLGraph for a batch of graphs.
+            g: DGLGraph for a batch of graphs.
             state_attr: State attrs for a batch of graphs.
-            return_all_layer_output: Whether to return outputs of all layers.
             **kwargs: For future flexibility. Not used at the moment.
-
-        Returns:
-            output: output: Output property for a batch of graphs
         """
         # Obtain graph, with distances and relative position vectors
         bond_vec, bond_dist = compute_pair_vector_and_distance(g)
@@ -264,6 +292,27 @@ class TensorNet(MatGLModel):
 
         g.ndata["node_feat"] = x
         fea_dict["readout"] = x
+        return fea_dict
+
+    def forward(
+        self,
+        g: dgl.DGLGraph,
+        state_attr: torch.Tensor | None = None,
+        return_all_layer_output: bool = False,
+        **kwargs,
+    ):
+        """
+
+        Args:
+            g : DGLGraph for a batch of graphs.
+            state_attr: State attrs for a batch of graphs.
+            return_all_layer_output: Whether to return outputs of all layers.
+            **kwargs: For future flexibility. Not used at the moment.
+
+        Returns:
+            output: output: Output property for a batch of graphs
+        """
+        fea_dict = self.forward_features(g=g, state_attr=state_attr)
 
         if self.is_intensive:
             node_vec = self.readout(g)

--- a/src/matgl/models/_tensornet_pyg.py
+++ b/src/matgl/models/_tensornet_pyg.py
@@ -201,22 +201,45 @@ class TensorNet(MatGLModel):
 
         self.out_norm = nn.LayerNorm(3 * units, dtype=dtype)
         self.linear = nn.Linear(3 * units, units, dtype=dtype)
-        if is_intensive:
+        self.is_intensive = is_intensive
+        self._build_readout(
+            units=units,
+            ntargets=ntargets,
+            readout_type=readout_type,
+            field=field,
+            activation=activation,
+            task_type=task_type,
+        )
+        self.reset_parameters()
+
+    def _build_readout(
+        self,
+        units: int,
+        ntargets: int,
+        readout_type: Literal["weighted_atom", "reduce_atom"],
+        field: Literal["node_feat", "edge_feat"],
+        activation: nn.Module,
+        task_type: Literal["classification", "regression"],
+    ) -> None:
+        """Build the readout / ``final_layer`` modules. Override in a subclass to
+        skip or replace the default readout construction (e.g. ``QET`` builds its
+        own atomic-energy head over a wider concatenated node feature).
+        """
+        if self.is_intensive:
             input_feats = units
             if readout_type == "weighted_atom":
                 self.readout = WeightedAtomReadOut(  # type:ignore[assignment]
                     in_feats=input_feats, dims=[units, units], activation=activation
                 )
-                readout_feats = units
+                readout_feats = input_feats
             else:
                 self.readout = ReduceReadOut("mean", field=field)  # type: ignore
-                readout_feats = input_feats  # type: ignore
+                readout_feats = input_feats
 
             dims_final_layer = [readout_feats, units, units, ntargets]
             self.final_layer = MLP(dims_final_layer, activation, activate_last=False)
             if task_type == "classification":
                 self.sigmoid = nn.Sigmoid()
-
         else:
             if task_type == "classification":
                 raise ValueError("Classification task cannot be extensive.")
@@ -225,9 +248,6 @@ class TensorNet(MatGLModel):
                 dims=[units, units],
                 num_targets=ntargets,  # type: ignore
             )
-
-        self.is_intensive = is_intensive
-        self.reset_parameters()
 
     def reset_parameters(self):
         self.tensor_embedding.reset_parameters()

--- a/src/matgl/models/_tensornet_pyg.py
+++ b/src/matgl/models/_tensornet_pyg.py
@@ -235,31 +235,28 @@ class TensorNet(MatGLModel):
             layer.reset_parameters()
         self.out_norm.reset_parameters()
 
-    def forward(
+    def forward_features(
         self,
         g: Any,
         state_attr: torch.Tensor | None = None,
-        return_all_layer_output: bool = False,
         **kwargs,
-    ):
-        """
+    ) -> dict[str, Any]:
+        """Run TensorNet's feature extraction up through the per-atom readout.
+
+        Returns a dict with intermediate features (``edge_attr``, ``embedding``,
+        ``gc_<i>``, ``readout``). Subclasses (e.g. ``QET``) reuse this without
+        re-implementing the embedding / interaction stack.
+
         Args:
             g: PyG Data object or dict with keys 'node_type'/'z', 'pos', 'edge_index',
                and optionally 'pbc_offshift', 'batch', 'num_graphs'.
             state_attr: State attrs for a batch of graphs.
-            return_all_layer_output: Whether to return outputs of all intermediate layers.
             **kwargs: For future flexibility. Not used at the moment.
-
-        Returns:
-            output: Output property for a batch of graphs, or a dict of layer outputs
-            when ``return_all_layer_output=True``.
         """
         z = getattr(g, "node_type", getattr(g, "z", None))
         pos = g.pos
         edge_index = g.edge_index
         pbc_offshift = getattr(g, "pbc_offshift", None)
-        batch = getattr(g, "batch", None)
-        num_graphs = getattr(g, "num_graphs", None)
 
         # Bond vectors and distances
         bond_vec, bond_dist = compute_pair_vector_and_distance(pos, edge_index, pbc_offshift)
@@ -307,6 +304,31 @@ class TensorNet(MatGLModel):
         x = self.out_norm(x)
         x = self.linear(x)
         fea_dict["readout"] = x
+        return fea_dict
+
+    def forward(
+        self,
+        g: Any,
+        state_attr: torch.Tensor | None = None,
+        return_all_layer_output: bool = False,
+        **kwargs,
+    ):
+        """
+        Args:
+            g: PyG Data object or dict with keys 'node_type'/'z', 'pos', 'edge_index',
+               and optionally 'pbc_offshift', 'batch', 'num_graphs'.
+            state_attr: State attrs for a batch of graphs.
+            return_all_layer_output: Whether to return outputs of all intermediate layers.
+            **kwargs: For future flexibility. Not used at the moment.
+
+        Returns:
+            output: Output property for a batch of graphs, or a dict of layer outputs
+            when ``return_all_layer_output=True``.
+        """
+        fea_dict = self.forward_features(g=g, state_attr=state_attr)
+        x = fea_dict["readout"]
+        batch = getattr(g, "batch", None)
+        num_graphs = getattr(g, "num_graphs", None)
 
         if self.is_intensive:
             node_vec = self.readout(x, batch)

--- a/src/matgl/models/_tensornet_pyg.py
+++ b/src/matgl/models/_tensornet_pyg.py
@@ -10,7 +10,6 @@ please refer to::
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -46,8 +45,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     from matgl.graph._converters_pyg import GraphConverter
-
-logger = logging.getLogger(__file__)
 
 
 class TensorNet(MatGLModel):
@@ -136,16 +133,12 @@ class TensorNet(MatGLModel):
                 f"Invalid activation type, please try using one of {[af.name for af in ActivationFunction]}"
             ) from None
 
-        # Resolve warp availability
-        if use_warp is None:
-            self._use_warp = _warp_available
-        elif use_warp and not _warp_available:
+        if use_warp and not _warp_available:
             raise ImportError(
                 "use_warp=True but nvalchemi-toolkit-ops is not installed. "
                 "Install it or pass use_warp=False to use the plain PyG backend."
             )
-        else:
-            self._use_warp = use_warp
+        self._use_warp = _warp_available if use_warp is None else use_warp
 
         self.element_types = element_types  # type: ignore
 
@@ -192,11 +185,8 @@ class TensorNet(MatGLModel):
         )
 
         self.layers = nn.ModuleList(
-            [
-                InteractionCls(num_rbf, units, activation, cutoff, equivariance_invariance_group, dtype)
-                for _ in range(nblocks)
-                if nblocks != 0
-            ]
+            InteractionCls(num_rbf, units, activation, cutoff, equivariance_invariance_group, dtype)
+            for _ in range(nblocks)
         )
 
         self.out_norm = nn.LayerNorm(3 * units, dtype=dtype)
@@ -225,22 +215,7 @@ class TensorNet(MatGLModel):
         skip or replace the default readout construction (e.g. ``QET`` builds its
         own atomic-energy head over a wider concatenated node feature).
         """
-        if self.is_intensive:
-            input_feats = units
-            if readout_type == "weighted_atom":
-                self.readout = WeightedAtomReadOut(  # type:ignore[assignment]
-                    in_feats=input_feats, dims=[units, units], activation=activation
-                )
-                readout_feats = input_feats
-            else:
-                self.readout = ReduceReadOut("mean", field=field)  # type: ignore
-                readout_feats = input_feats
-
-            dims_final_layer = [readout_feats, units, units, ntargets]
-            self.final_layer = MLP(dims_final_layer, activation, activate_last=False)
-            if task_type == "classification":
-                self.sigmoid = nn.Sigmoid()
-        else:
+        if not self.is_intensive:
             if task_type == "classification":
                 raise ValueError("Classification task cannot be extensive.")
             self.final_layer = WeightedReadOut(
@@ -248,6 +223,17 @@ class TensorNet(MatGLModel):
                 dims=[units, units],
                 num_targets=ntargets,  # type: ignore
             )
+            return
+
+        if readout_type == "weighted_atom":
+            self.readout = WeightedAtomReadOut(  # type:ignore[assignment]
+                in_feats=units, dims=[units, units], activation=activation
+            )
+        else:
+            self.readout = ReduceReadOut("mean", field=field)  # type: ignore
+        self.final_layer = MLP([units, units, units, ntargets], activation, activate_last=False)
+        if task_type == "classification":
+            self.sigmoid = nn.Sigmoid()
 
     def reset_parameters(self):
         self.tensor_embedding.reset_parameters()
@@ -357,19 +343,14 @@ class TensorNet(MatGLModel):
                 output = self.sigmoid(output)
             output = torch.squeeze(output)
         else:
-            atomic_energies = self.final_layer(x)
-            if batch is not None:
-                # edge case: avoid losing the batch dimension on size-(1,1) outputs
-                if atomic_energies.shape == (1, 1):
-                    atomic_energies = atomic_energies.squeeze(-1)
-                else:
-                    atomic_energies = atomic_energies.squeeze()
+            atomic_energies = self.final_layer(x).view(-1)
+            if batch is None:
+                output = atomic_energies.sum()
+            else:
                 batch_long = batch.to(torch.long)
                 if num_graphs is None:
                     num_graphs = int(batch_long.max().item()) + 1
                 output = scatter_add(atomic_energies, batch_long, dim_size=num_graphs)  # type: ignore[arg-type]
-            else:
-                output = torch.sum(atomic_energies, dim=0, keepdim=True).squeeze()
 
         fea_dict["final"] = output
         if return_all_layer_output:

--- a/src/matgl/models/_tensornet_pyg.py
+++ b/src/matgl/models/_tensornet_pyg.py
@@ -55,6 +55,7 @@ class TensorNet(MatGLModel):
     """
 
     __version__ = 2
+    final_layer: MLP | WeightedReadOut
 
     def __init__(
         self,

--- a/tests/electrostatics/test_elec_pot.py
+++ b/tests/electrostatics/test_elec_pot.py
@@ -1,0 +1,116 @@
+"""Tests for the electrostatic-potential aggregator, including DGL <-> PyG parity."""
+
+from __future__ import annotations
+
+import importlib
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import matgl
+from matgl.config import COULOMB_CONSTANT
+from matgl.electrostatics._elec_pot_pyg import ElectrostaticPotential as ElectrostaticPotentialPyG
+from matgl.utils.cutoff import polynomial_cutoff
+
+
+def _has_dgl() -> bool:
+    try:
+        importlib.import_module("dgl")
+    except Exception:  # DGL has many import-time failure modes (missing libs, version skew)
+        return False
+    return True
+
+
+def _make_pyg_graph(pos: torch.Tensor, edge_index: torch.Tensor) -> SimpleNamespace:
+    return SimpleNamespace(pos=pos, edge_index=edge_index)
+
+
+def test_elec_pot_pyg_two_atoms_against_analytic():
+    """Two atoms, single bidirectional bond: hand-computed potential must match."""
+    cutoff = 5.0
+    pos = torch.tensor([[0.0, 0.0, 0.0], [1.5, 0.0, 0.0]], dtype=matgl.float_th)
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    charge = torch.tensor([0.7, -0.7], dtype=matgl.float_th)
+    sigma = torch.tensor([0.5, 0.6], dtype=matgl.float_th)
+
+    g = _make_pyg_graph(pos, edge_index)
+    out = ElectrostaticPotentialPyG(element_types=("X", "Y"), cutoff=cutoff)(g, charge=charge, sigma=sigma)
+
+    r = float(torch.linalg.norm(pos[0] - pos[1]))
+    gamma = math.sqrt(0.5**2 + 0.6**2)
+    cutoff_factor = float(polynomial_cutoff(torch.tensor(r, dtype=matgl.float_th), cutoff))
+    edge_factor = math.erf(r / math.sqrt(2.0) / gamma) * cutoff_factor / r * COULOMB_CONSTANT
+    expected = torch.tensor([charge[1].item() * edge_factor, charge[0].item() * edge_factor], dtype=matgl.float_th)
+
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_elec_pot_pyg_zero_charges_give_zero_potential():
+    """No charge anywhere -> identically zero potential (sanity)."""
+    pos = torch.tensor([[0.0, 0.0, 0.0], [1.5, 0.0, 0.0], [0.0, 1.7, 0.0]], dtype=matgl.float_th)
+    edge_index = torch.tensor([[0, 1, 0, 2, 1, 2], [1, 0, 2, 0, 2, 1]], dtype=torch.long)
+    charge = torch.zeros(3, dtype=matgl.float_th)
+    sigma = torch.tensor([0.5, 0.5, 0.5], dtype=matgl.float_th)
+
+    g = _make_pyg_graph(pos, edge_index)
+    out = ElectrostaticPotentialPyG(element_types=("X",), cutoff=5.0)(g, charge=charge, sigma=sigma)
+    assert torch.allclose(out, torch.zeros_like(out))
+
+
+def test_elec_pot_pyg_gradient_flow():
+    """Gradients must flow back to atomic positions via the differentiable cutoff and erf."""
+    pos = torch.tensor([[0.0, 0.0, 0.0], [1.5, 0.0, 0.0]], dtype=torch.double, requires_grad=True)
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    charge = torch.tensor([0.4, -0.4], dtype=torch.double)
+    sigma = torch.tensor([0.5, 0.5], dtype=torch.double)
+
+    g = _make_pyg_graph(pos, edge_index)
+    module = ElectrostaticPotentialPyG(element_types=("X",), cutoff=5.0).double()
+    out = module(g, charge=charge, sigma=sigma).sum()
+    out.backward()
+    assert pos.grad is not None
+    assert torch.isfinite(pos.grad).all()
+    # Symmetric bond: grads on the two atoms must be exact opposites.
+    assert torch.allclose(pos.grad[0], -pos.grad[1], atol=1e-10)
+
+
+@pytest.mark.skipif(not _has_dgl(), reason="DGL not importable in this environment")
+def test_elec_pot_dgl_pyg_parity():
+    """Identical inputs must give identical per-atom potentials in DGL and PyG."""
+    import dgl
+
+    from matgl.electrostatics._elec_pot_dgl import ElectrostaticPotential as ElectrostaticPotentialDGL
+
+    cutoff = 5.0
+    torch.manual_seed(0)
+    n = 6
+    pos = torch.randn(n, 3, dtype=matgl.float_th)
+    # Build a fully connected (no self-loops) symmetric edge list.
+    src, dst = [], []
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            src.append(i)
+            dst.append(j)
+    src_t = torch.tensor(src, dtype=torch.long)
+    dst_t = torch.tensor(dst, dtype=torch.long)
+    bond_dist = torch.linalg.norm(pos[src_t] - pos[dst_t], dim=1)
+
+    charge = torch.randn(n, dtype=matgl.float_th)
+    sigma = torch.rand(n, dtype=matgl.float_th) + 0.3
+
+    # DGL side
+    g_dgl = dgl.graph((src_t, dst_t), num_nodes=n)
+    g_dgl.ndata["charge"] = charge
+    g_dgl.ndata["sigma"] = sigma
+    g_dgl.edata["bond_dist"] = bond_dist
+    out_dgl = ElectrostaticPotentialDGL(element_types=("X",), cutoff=cutoff)(g_dgl).ndata["elec_pot"]
+
+    # PyG side
+    g_pyg = _make_pyg_graph(pos, torch.stack([src_t, dst_t], dim=0))
+    out_pyg = ElectrostaticPotentialPyG(element_types=("X",), cutoff=cutoff)(g_pyg, charge=charge, sigma=sigma)
+
+    assert torch.allclose(out_dgl, out_pyg, atol=1e-6)

--- a/tests/electrostatics/test_fast_qeq.py
+++ b/tests/electrostatics/test_fast_qeq.py
@@ -1,0 +1,94 @@
+"""Tests for the QEq solver, including DGL <-> PyG numerical parity."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import matgl
+from matgl.electrostatics._fast_qeq_pyg import LinearQeq as LinearQeqPyG
+
+
+def _has_dgl() -> bool:
+    try:
+        importlib.import_module("dgl")
+    except Exception:  # DGL has many import-time failure modes (missing libs, version skew)
+        return False
+    return True
+
+
+def test_qeq_pyg_two_atoms_analytic():
+    """Closed-form solution must hold for a 2-atom graph with known chi/hardness."""
+    chi = torch.tensor([0.4, -0.6], dtype=matgl.float_th)
+    hardness = torch.tensor([2.0, 1.5], dtype=matgl.float_th)
+    total_charge = torch.tensor([0.0], dtype=matgl.float_th)
+
+    h_inv = hardness.reciprocal()
+    expected = -chi * h_inv + h_inv * (total_charge.sum() + (chi * h_inv).sum()) / h_inv.sum()
+
+    g = SimpleNamespace(batch=torch.zeros(2, dtype=torch.long), num_graphs=1)
+
+    out = LinearQeqPyG()(g, total_charge, chi, hardness)
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_qeq_pyg_batch_charge_conservation():
+    """Per-graph charges must sum to the per-graph total_charge constraint."""
+    torch.manual_seed(0)
+    chi = torch.randn(7, dtype=matgl.float_th)
+    hardness = torch.rand(7, dtype=matgl.float_th) + 0.5
+    batch = torch.tensor([0, 0, 1, 1, 1, 2, 2], dtype=torch.long)
+    total_charge = torch.tensor([0.0, 1.0, -2.0], dtype=matgl.float_th)
+
+    g = SimpleNamespace(batch=batch, num_graphs=3)
+
+    charges = LinearQeqPyG()(g, total_charge, chi, hardness)
+    summed = torch.zeros(3, dtype=matgl.float_th).scatter_add_(0, batch, charges)
+    assert torch.allclose(summed, total_charge, atol=1e-6)
+
+
+def test_qeq_pyg_q_ref_overrides_total_charge():
+    """When ``q_ref`` is present on the graph, its per-graph sum overrides ``total_charge``."""
+    chi = torch.tensor([0.1, -0.2, 0.3], dtype=matgl.float_th)
+    hardness = torch.tensor([1.5, 1.0, 2.0], dtype=matgl.float_th)
+    q_ref = torch.tensor([0.4, 0.4, -1.0], dtype=matgl.float_th)
+
+    g = SimpleNamespace(batch=torch.tensor([0, 0, 1], dtype=torch.long), num_graphs=2, q_ref=q_ref)
+
+    charges = LinearQeqPyG()(g, total_charge=torch.tensor([99.0, 99.0]), chi=chi, hardness=hardness)
+    summed = torch.zeros(2, dtype=matgl.float_th).scatter_add_(0, g.batch, charges)
+    expected = torch.tensor([0.8, -1.0], dtype=matgl.float_th)
+    assert torch.allclose(summed, expected, atol=1e-6)
+
+
+@pytest.mark.skipif(not _has_dgl(), reason="DGL not importable in this environment")
+def test_qeq_dgl_pyg_parity():
+    """DGL and PyG QEq solvers must produce identical charges on the same input."""
+    import dgl
+
+    from matgl.electrostatics._fast_qeq_dgl import LinearQeq as LinearQeqDGL
+
+    torch.manual_seed(7)
+    n1, n2 = 4, 3
+    chi = torch.randn(n1 + n2, dtype=matgl.float_th)
+    hardness = torch.rand(n1 + n2, dtype=matgl.float_th) + 0.5
+    total_charge = torch.tensor([0.5, -1.5], dtype=matgl.float_th)
+
+    # DGL side: build two trivial graphs (edges don't matter for QEq) and batch them.
+    g1 = dgl.graph(([0, 1, 2, 3], [1, 2, 3, 0]), num_nodes=n1)
+    g2 = dgl.graph(([0, 1, 2], [1, 2, 0]), num_nodes=n2)
+    g1.ndata["chi"] = chi[:n1]
+    g1.ndata["hardness"] = hardness[:n1]
+    g2.ndata["chi"] = chi[n1:]
+    g2.ndata["hardness"] = hardness[n1:]
+    bg = dgl.batch([g1, g2])
+    out_dgl = LinearQeqDGL()(bg, total_charge.reshape(-1, 1)).ndata["charge"]
+
+    # PyG side: equivalent batch metadata.
+    g = SimpleNamespace(batch=torch.tensor([0] * n1 + [1] * n2, dtype=torch.long), num_graphs=2)
+    out_pyg = LinearQeqPyG()(g, total_charge, chi, hardness)
+
+    assert torch.allclose(out_dgl, out_pyg, atol=1e-6)

--- a/tests/models/test_qet_pyg.py
+++ b/tests/models/test_qet_pyg.py
@@ -1,0 +1,126 @@
+"""Tests for the PyG QET model, including DGL <-> PyG numerical parity."""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+import torch
+
+import matgl
+
+if matgl.config.BACKEND != "PYG":
+    pytest.skip("Skipping PyG tests", allow_module_level=True)
+
+from matgl.models._qet_pyg import QET
+
+
+def _has_dgl() -> bool:
+    try:
+        importlib.import_module("dgl")
+    except Exception:  # DGL has many import-time failure modes (missing libs, version skew)
+        return False
+    return True
+
+
+def test_qet_pyg(graph_MoS_pyg):
+    """Forward across activations + save/load + SO(3) variant."""
+    torch.manual_seed(0)
+    torch.use_deterministic_algorithms(True)
+
+    _, graph, _ = graph_MoS_pyg
+    activations = ["swish", "tanh", "sigmoid", "softplus2", "softexp"]
+
+    for act in activations:
+        model = QET(is_intensive=False, activation_type=act, use_warp=False)
+        output = model(g=graph, total_charge=torch.tensor([0.0]))
+        assert torch.numel(output) == 1
+
+    # Save / load round-trip
+    model.save(".")
+    QET.load(".")
+    for fname in ("model.pt", "model.json", "state.pt"):
+        os.remove(fname)
+
+    # SO(3) variant constructs cleanly
+    model = QET(is_intensive=False, equivariance_invariance_group="SO(3)", use_warp=False)
+    output = model(g=graph, total_charge=torch.tensor([0.0]))
+    assert torch.numel(output) == 1
+
+
+def test_qet_pyg_return_features(graph_MoS_pyg):
+    """`return_features=True` returns (node_feat, atomic_energies) with the right shapes."""
+    torch.manual_seed(0)
+    _, graph, _ = graph_MoS_pyg
+    model = QET(is_intensive=False, return_features=True, use_warp=False)
+    node_feat, atomic_energies = model(g=graph, total_charge=torch.tensor([0.0]))
+    n_nodes = graph.pos.shape[0]
+    # +1 charge, +1 elec_pot
+    assert node_feat.shape == (n_nodes, model.units + 2)
+    assert atomic_energies.shape[0] == n_nodes
+
+
+def test_qet_pyg_include_magmom(graph_MoS_pyg):
+    """Smoke-check the magmom branch."""
+    torch.manual_seed(0)
+    _, graph, _ = graph_MoS_pyg
+    model = QET(is_intensive=False, include_magmom=True, return_features=True, use_warp=False)
+    node_feat, _ = model(g=graph, total_charge=torch.tensor([0.0]))
+    n_nodes = graph.pos.shape[0]
+    # +1 charge, +1 elec_pot, +1 magmom
+    assert node_feat.shape == (n_nodes, model.units + 3)
+
+
+def test_qet_pyg_is_hardness_envs(graph_MoS_pyg):
+    """Smoke-check the environment-dependent hardness branch (MLP head instead of per-element parameter)."""
+    torch.manual_seed(0)
+    _, graph, _ = graph_MoS_pyg
+    model = QET(is_intensive=False, is_hardness_envs=True, use_warp=False)
+    output = model(g=graph, total_charge=torch.tensor([0.0]))
+    assert torch.numel(output) == 1
+
+
+@pytest.mark.skipif(not _has_dgl(), reason="DGL not importable in this environment")
+def test_qet_dgl_pyg_parity(MoS):
+    """DGL and PyG QET produce equal energies on the same structure with shared weights."""
+    import dgl  # noqa: F401  (proves DGL is importable in this env)
+
+    from matgl.ext._pymatgen_dgl import Structure2Graph as Structure2GraphDGL
+    from matgl.ext._pymatgen_pyg import Structure2Graph as Structure2GraphPyG
+    from matgl.models._qet_dgl import QET as QETDGL
+
+    elements = ("Mo", "S")
+    cutoff = 5.0
+
+    # Build identical-input graphs in both backends.
+    conv_dgl = Structure2GraphDGL(element_types=elements, cutoff=cutoff)
+    g_dgl, lat_dgl, _ = conv_dgl.get_graph(MoS)
+    g_dgl.edata["pbc_offshift"] = torch.matmul(g_dgl.edata["pbc_offset"], lat_dgl[0])
+    g_dgl.ndata["pos"] = g_dgl.ndata["frac_coords"] @ lat_dgl[0]
+
+    conv_pyg = Structure2GraphPyG(element_types=elements, cutoff=cutoff)
+    g_pyg, lat_pyg, _ = conv_pyg.get_graph(MoS)
+    g_pyg.pbc_offshift = torch.matmul(g_pyg.pbc_offset, lat_pyg[0])
+    g_pyg.pos = g_pyg.frac_coords @ lat_pyg[0]
+
+    # Construct both models with identical config and copy weights from PyG -> DGL.
+    torch.manual_seed(42)
+    torch.use_deterministic_algorithms(True)
+    pyg_model = QET(element_types=elements, is_intensive=False, cutoff=cutoff, use_warp=False).eval()
+    torch.manual_seed(42)
+    dgl_model = QETDGL(element_types=elements, is_intensive=False, cutoff=cutoff).eval()
+
+    # Both models share the same architecture and key names since QET DGL and PyG
+    # both subclass their respective TensorNet. Load PyG state into DGL with strict=False
+    # (some buffers like `pi`, `sqrt2` exist in both backends and match by name).
+    missing, _unexpected = dgl_model.load_state_dict(pyg_model.state_dict(), strict=False)
+    # Allow a small set of buffers / module-internal differences but require all
+    # trainable weights to load on both sides.
+    trainable_keys_pyg = {k for k, v in pyg_model.state_dict().items() if v.dtype.is_floating_point}
+    not_loaded = trainable_keys_pyg.intersection(missing)
+    assert not not_loaded, f"Trainable PyG keys missing from DGL state_dict: {sorted(not_loaded)[:5]}"
+
+    e_pyg = pyg_model(g=g_pyg, total_charge=torch.tensor([0.0]))
+    e_dgl = dgl_model(g=g_dgl, total_charge=torch.tensor([0.0]))
+    assert torch.allclose(e_pyg, e_dgl, atol=1e-4), f"PyG={e_pyg.item()} vs DGL={e_dgl.item()}"

--- a/tests/models/test_qet_pyg.py
+++ b/tests/models/test_qet_pyg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 
+import numpy as np
 import pytest
 import torch
 
@@ -124,3 +125,125 @@ def test_qet_dgl_pyg_parity(MoS):
     e_pyg = pyg_model(g=g_pyg, total_charge=torch.tensor([0.0]))
     e_dgl = dgl_model(g=g_dgl, total_charge=torch.tensor([0.0]))
     assert torch.allclose(e_pyg, e_dgl, atol=1e-4), f"PyG={e_pyg.item()} vs DGL={e_dgl.item()}"
+
+
+@pytest.mark.skipif(not _has_dgl(), reason="DGL not importable in this environment")
+def test_qet_dgl_pyg_training_parity(MoS):
+    """Train QET DGL and QET PyG for ~10 epochs on a 5-structure MoS toy dataset
+    and assert that per-structure energies / forces stay equal across backends.
+
+    Dataset: the conftest ``MoS`` (cubic 4 A, Mo[0,0,0], S[0.5,0.5,0.5]) plus 4
+    small fractional-coord perturbations. Reference labels: charges of +4 / -2
+    on the base structure (sum fed via ``total_charge``), with small per-structure
+    perturbations of charge / energy / force on the others. Loss is energy MSE +
+    force MSE; same Adam optimizer, same data ordering, no shuffling.
+
+    Both models start from identical weights (PyG state copied into DGL) and
+    must produce step-by-step identical predictions throughout training; the
+    only allowed drift is float32 round-off in scatter / aggregation order.
+    """
+    import dgl  # noqa: F401
+
+    from matgl.ext._pymatgen_dgl import Structure2Graph as Structure2GraphDGL
+    from matgl.ext._pymatgen_pyg import Structure2Graph as Structure2GraphPyG
+    from matgl.models._qet_dgl import QET as QETDGL
+
+    elements = ("Mo", "S")
+    cutoff = 5.0
+    n_structures = 5
+    n_epochs = 10
+    seed = 0
+
+    # --- Build toy dataset (5 structures + reference q / E / F) -----------
+    rng = np.random.default_rng(seed)
+    structures, ref_q, ref_E, ref_F = [], [], [], []
+    for i in range(n_structures):
+        s = MoS.copy()
+        if i > 0:
+            for site in s:
+                site.frac_coords = site.frac_coords + rng.uniform(-0.02, 0.02, 3)
+        structures.append(s)
+        eps = 0.0 if i == 0 else float(rng.uniform(-0.05, 0.05))
+        ref_q.append(np.array([4.0 + eps, -2.0 - eps], dtype=np.float64))
+        ref_E.append(0.0 if i == 0 else float(rng.uniform(-0.1, 0.1)))
+        ref_F.append(rng.uniform(-0.05, 0.05, (2, 3)) if i > 0 else np.zeros((2, 3), dtype=np.float64))
+
+    ref_E_t = [torch.tensor(e, dtype=torch.get_default_dtype()) for e in ref_E]
+    ref_F_t = [torch.tensor(f, dtype=torch.get_default_dtype()) for f in ref_F]
+    total_q = [torch.tensor([float(q.sum())], dtype=torch.get_default_dtype()) for q in ref_q]
+
+    # --- Backend graph builders ------------------------------------------
+    conv_dgl = Structure2GraphDGL(element_types=elements, cutoff=cutoff)
+    conv_pyg = Structure2GraphPyG(element_types=elements, cutoff=cutoff)
+
+    def _dgl_graphs():
+        out = []
+        for s in structures:
+            g, lat, _ = conv_dgl.get_graph(s)
+            g.edata["pbc_offshift"] = torch.matmul(g.edata["pbc_offset"], lat[0])
+            out.append((g, lat))
+        return out
+
+    def _pyg_graphs():
+        out = []
+        for s in structures:
+            g, lat, _ = conv_pyg.get_graph(s)
+            g.pbc_offshift = torch.matmul(g.pbc_offset, lat[0])
+            out.append((g, lat))
+        return out
+
+    def _forward_dgl(model, g, lat, tot_q):
+        pos = (g.ndata["frac_coords"] @ lat[0]).detach().clone().requires_grad_(True)
+        g.ndata["pos"] = pos
+        e = model(g=g, total_charge=tot_q)
+        (grads,) = torch.autograd.grad(e.sum(), pos, create_graph=True, retain_graph=True)
+        return e, -grads
+
+    def _forward_pyg(model, g, lat, tot_q):
+        pos = (g.frac_coords @ lat[0]).detach().clone().requires_grad_(True)
+        g.pos = pos
+        e = model(g=g, total_charge=tot_q)
+        (grads,) = torch.autograd.grad(e.sum(), pos, create_graph=True, retain_graph=True)
+        return e, -grads
+
+    def _train(model, fwd, graphs, lr=1e-3):
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        for _ in range(n_epochs):
+            opt.zero_grad()
+            loss = torch.zeros(())
+            for i, (g, lat) in enumerate(graphs):
+                e_p, f_p = fwd(model, g, lat, total_q[i])
+                loss = loss + (e_p.squeeze() - ref_E_t[i]) ** 2 + ((f_p - ref_F_t[i]) ** 2).mean()
+            loss.backward()
+            opt.step()
+
+    def _predict(model, fwd, graphs):
+        es, fs = [], []
+        for i, (g, lat) in enumerate(graphs):
+            e_p, f_p = fwd(model, g, lat, total_q[i])
+            es.append(e_p.detach().clone())
+            fs.append(f_p.detach().clone())
+        return es, fs
+
+    # --- Build models with identical weights ------------------------------
+    torch.manual_seed(seed)
+    pyg_model = QET(element_types=elements, is_intensive=False, cutoff=cutoff, use_warp=False).train()
+    torch.manual_seed(seed)
+    dgl_model = QETDGL(element_types=elements, is_intensive=False, cutoff=cutoff).train()
+    missing, _ = dgl_model.load_state_dict(pyg_model.state_dict(), strict=False)
+    trainable_pyg = {k for k, v in pyg_model.state_dict().items() if v.dtype.is_floating_point}
+    not_loaded = trainable_pyg.intersection(missing)
+    assert not not_loaded, f"Trainable PyG keys missing from DGL state_dict: {sorted(not_loaded)[:5]}"
+
+    # --- Train both backends ---------------------------------------------
+    _train(pyg_model, _forward_pyg, _pyg_graphs())
+    _train(dgl_model, _forward_dgl, _dgl_graphs())
+
+    # --- Compare post-training predictions on every structure ------------
+    e_pyg, f_pyg = _predict(pyg_model, _forward_pyg, _pyg_graphs())
+    e_dgl, f_dgl = _predict(dgl_model, _forward_dgl, _dgl_graphs())
+
+    max_de = max(float((ep - ed).abs().max()) for ep, ed in zip(e_pyg, e_dgl, strict=True))
+    max_df = max(float((fp - fd).abs().max()) for fp, fd in zip(f_pyg, f_dgl, strict=True))
+    assert max_de < 1e-6, f"max |dE| after training = {max_de:.3e}"
+    assert max_df < 1e-6, f"max |dF| after training = {max_df:.3e}"

--- a/uv.lock
+++ b/uv.lock
@@ -362,30 +362,30 @@ css = [
 
 [[package]]
 name = "boto3"
-version = "1.42.96"
+version = "1.43.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/cd/bba36079f5d4bd63db7385e6b9dc1845db32407c3f18f56aaddafb75097f/boto3-1.43.2.tar.gz", hash = "sha256:be951cc22769fbcda73fac523b031ee38db45c3ae2b0d828c76b8f6e8e683073", size = 113108, upload-time = "2026-05-01T19:43:13.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e5/c9cee72ef678dabcc27acaf8228a2d4157ad26b00e1cc5d48886f8a94c2c/boto3-1.43.2-py3-none-any.whl", hash = "sha256:796e859cfb5e93c55276ce746f8020f691eda6b68a0ec4ce4f6fd07a1cca6859", size = 140501, upload-time = "2026-05-01T19:43:10.5Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.96"
+version = "1.43.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/77/2c333622a1d47cf5bf73cdcab0cb6c92addafbef2ec05f81b9f75687d9e5/botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250", size = 15263344, upload-time = "2026-04-24T19:47:05.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/b0/65d4c85f16367fb6147d391652d0c386f24b029536f7026e7b98740166cd/botocore-1.43.2.tar.gz", hash = "sha256:7b2ec87b6d0720bff920451ce930e71c2a99cdea48d0eaa66ccf0b21ea747e03", size = 15301186, upload-time = "2026-05-01T19:42:59.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/56/152c3a859ca1b9d77ed16deac3cf81682013677c68cf5715698781fc81bd/botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a", size = 14945920, upload-time = "2026-04-24T19:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/52/f57ded73f1527a18e0712281eb49c4ae240038bb4dc7083fd288b4adc811/botocore-1.43.2-py3-none-any.whl", hash = "sha256:b823454d751a1c24bb403b5b07ab65007689654abb21787df923684e0743976c", size = 14982693, upload-time = "2026-05-01T19:42:54.602Z" },
 ]
 
 [[package]]
@@ -812,10 +812,10 @@ wheels = [
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.5.3"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/d6/ac63065d33dd700fee7ebd7d287332401b54e31b9346e142f871e1f0b116/cuda_pathfinder-1.5.3-py3-none-any.whl", hash = "sha256:dff021123aedbb4117cc7ec81717bbfe198fb4e8b5f1ee57e0e084fec5c8577d", size = 49991, upload-time = "2026-04-14T20:09:27.037Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
 ]
 
 [[package]]
@@ -1225,11 +1225,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [package.optional-dependencies]
@@ -1338,7 +1338,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.12.0"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1351,9 +1351,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
+    { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
 ]
 
 [[package]]
@@ -1514,14 +1514,14 @@ wheels = [
 
 [[package]]
 name = "jedi"
-version = "0.19.2"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parso" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.6"
+version = "4.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1770,9 +1770,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/d5/730628e03fff2e8a8e8ccdaedde1489ab1309f9a4fa2536248884e30b7c7/jupyterlab-4.5.6.tar.gz", hash = "sha256:642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42", size = 23970670, upload-time = "2026-03-11T14:17:04.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/1b/dad6fdcc658ed7af26fdf3841e7394072c9549a8b896c381ab49dd11e2d9/jupyterlab-4.5.6-py3-none-any.whl", hash = "sha256:d6b3dac883aa4d9993348e0f8e95b24624f75099aed64eab6a4351a9cdd1e580", size = 12447124, upload-time = "2026-03-11T14:17:00.229Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
 ]
 
 [[package]]
@@ -2736,7 +2736,7 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.5"
+version = "7.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
@@ -2745,9 +2745,9 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/6d/41052c48d6f6349ca0a7c4d1f6a78464de135e6d18f5829ba2510e62184c/notebook-7.5.5.tar.gz", hash = "sha256:dc0bfab0f2372c8278c457423d3256c34154ac2cc76bf20e9925260c461013c3", size = 14169167, upload-time = "2026-03-11T16:32:51.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/cbd1deb9f07446241e88f8d5fecccd95b249bca0b4e5482214a4d1714c49/notebook-7.5.5-py3-none-any.whl", hash = "sha256:a7c14dbeefa6592e87f72290ca982e0c10f5bbf3786be2a600fda9da2764a2b8", size = 14578929, upload-time = "2026-03-11T16:32:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d6/1fd0646b9bbd9efbb0b8ae21b2325fbef515769a5621c03e31d8eb8da587/notebook-7.5.6-py3-none-any.whl", hash = "sha256:4dde3f8fb55fa8fb7946d58c6e869ce9baf46d00fc070664f62604569d0faca0", size = 14581730, upload-time = "2026-04-30T11:46:22.342Z" },
 ]
 
 [[package]]
@@ -2889,7 +2889,8 @@ dependencies = [
     { name = "rich" },
     { name = "tensordict" },
     { name = "torch" },
-    { name = "zarr" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "zarr", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/8e/74e7f828f60e2baddf9482f3bd7bfa2af996b8242c6cfd4c32dcc1f5b393/nvalchemi_toolkit-0.1.0-py3-none-any.whl", hash = "sha256:fa5e0daecbd2be425f1e9840eb5cbc7652f3232831489c51df80f4b9b16e4f7c", size = 332937, upload-time = "2026-04-16T08:36:24.457Z" },
@@ -3227,11 +3228,11 @@ wheels = [
 
 [[package]]
 name = "parso"
-version = "0.8.6"
+version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
 ]
 
 [[package]]
@@ -3387,25 +3388,25 @@ wheels = [
 
 [[package]]
 name = "plum-dispatch"
-version = "2.8.0"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/2f2b0dd84edbb2951a845ba98d29f651bbbd467039c368fcfa22904905cd/plum_dispatch-2.8.0.tar.gz", hash = "sha256:453fc7bc67d2a39492c834b00c94d816871d148b5a0a5d3f49e2bbf2391e2619", size = 241272, upload-time = "2026-03-17T21:24:41.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ac/c502295727dd9c9bd2105c130ae4420762536faf411ed94b5b13c31b3e6b/plum_dispatch-2.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b3aa8ff3f5a356e4a8f659bb35ce52c2dd9c67bfefb89fe35204bc9be3be77a", size = 162215, upload-time = "2026-03-17T21:24:26.81Z" },
-    { url = "https://files.pythonhosted.org/packages/65/51/ddb87d0f7190d176d2c22174b6ebc02c5d6d1d571dec2a5ab3f388e8a1c8/plum_dispatch-2.8.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:71a8619fe9017d9741ab96c73443b50afe1b7159202d94b332a64fa2ed760cdf", size = 192110, upload-time = "2026-03-17T21:24:28.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/41/0115bb8a2a6d06f9698fec20ede13350897271b46173b3d9e75f1711f73f/plum_dispatch-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c7d033348a6d60940476b5be9132dd1a87cb0d0ba335ad3bd4213137162bbf5", size = 146574, upload-time = "2026-03-17T21:24:29.805Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a3/cdb8130cc05a13c75237d2be4821f38c0b99d1a64980b6529d788a43a501/plum_dispatch-2.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fca6b6dbed8c686f6f827e9c95f60334ba70ee27cccef1f44a50d42a30221748", size = 165288, upload-time = "2026-03-17T21:24:31.203Z" },
-    { url = "https://files.pythonhosted.org/packages/25/fe/b1dbbdd1864d4ca825b3b5079fca852ea5e5a4f223aa866702f751b02dba/plum_dispatch-2.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:599025e7bd7e16f198e5ccaad0ca51036fcbeb43eb41525a5ef705b9a25bb192", size = 194360, upload-time = "2026-03-17T21:24:32.531Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/01/a8947d5c92824a6bc019696e5d9f150178736ecd8e6766db38b38e0f0fda/plum_dispatch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0e6146881b71eb6a6355d18476bed356071d1dff45a7cf4ae31f7f4bffb01b9", size = 146826, upload-time = "2026-03-17T21:24:34.076Z" },
-    { url = "https://files.pythonhosted.org/packages/68/25/380300b3468417999ca0db0522eeae1017798519fe28753e8ad110718174/plum_dispatch-2.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d60c0040207495afddab3f80c498a5e8f9dab29f8d143468c51d668fe70ed291", size = 165256, upload-time = "2026-03-17T21:24:35.341Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/94e4e62ad437996341d03471bd398f3f6bf4c5f3a1fa524ba53f02b6896d/plum_dispatch-2.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88aaf08a562e7a559851679a051b32306b67fd403ed6070915a966f048a83e9", size = 193632, upload-time = "2026-03-17T21:24:37.035Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d2/772d1e3071971a30e70b78df421f51788354337a7f94957d910ba3cd8a5a/plum_dispatch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:53bc084b335e5071b72353830a9f2cdacd58c9e959089be5778b6d638b5062f9", size = 146931, upload-time = "2026-03-17T21:24:38.8Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/7d/6d1a0a5851fb590564045471bdd6f405426ae4214cafe530ceba297e5c0d/plum_dispatch-2.8.0-py3-none-any.whl", hash = "sha256:f5dfffc46de1d8208ba281fdb0f41d6065c7341c1fde76fc83b4b78810c30c7e", size = 44547, upload-time = "2026-03-17T21:24:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/20/7aa36a01b1689d427a9fc20c80b1c0bc8340d1413c8071f08fb1e9a01939/plum_dispatch-2.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25f62c2209b7bff00c6cdc25fe153ac09df304d7d833fab2852fc46fffbb7e87", size = 172039, upload-time = "2026-04-28T08:38:19.985Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/eee83f936500e3e0100ac421483fa78768fec70214e4ce0241187ec3a2f1/plum_dispatch-2.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4d34cab84908abbdff501e356296eba960ff5d5fc04668b71ebc6f9ff84fa2f", size = 203364, upload-time = "2026-04-28T08:38:21.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/05/78c229ccce36fbd6dbc1cde698baae57313515ff1bff6ebad28be46c9386/plum_dispatch-2.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:1050150b6ae3600ac19a406b23cb7d0707825b227f608a54b8be9994d1f4b710", size = 152110, upload-time = "2026-04-28T08:38:22.975Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d6/fc6591336731b5e291319ec3c43d81cd6cc7940c9079183b333b85ed4d77/plum_dispatch-2.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:39a325b0b041fad687271d71abc11b5271d5a3b62af2c6b1271f4ececc3b59de", size = 175166, upload-time = "2026-04-28T08:38:24.467Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4d/5418649397b477ae08839564c97596ede5ef36523147899bb913bbe959d1/plum_dispatch-2.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d39b20a1af776a39e4a0833e97c6258d938e5d874c7f3537bb7d772c39718c1e", size = 205988, upload-time = "2026-04-28T08:38:25.838Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a5/28a6c4e45c4465a6e1a30d65206e913c217690752dc3c9261d78a9187aed/plum_dispatch-2.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:beb9b92c6994404a0d2dc83c857263f5da49519575e5cbb8a13060652746c44c", size = 152563, upload-time = "2026-04-28T08:38:27.37Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/18/19e01dbbaececb75815abb37bc71e10d87a7561829b4eae47ec3b342c94f/plum_dispatch-2.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78987caf558fbdd675a7a4a5c144069f1f9524610195123fb7d0f0234d0af01a", size = 174490, upload-time = "2026-04-28T08:38:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36662d76ae6d87aaa041fade036d2242f0b88b68c9fb4c96b7ba0026320065d3", size = 204734, upload-time = "2026-04-28T08:38:30.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/98/23d19326af0da251bb98a39f517ab6da983e5aad5eb9cc398b60933df2cc/plum_dispatch-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0d16daf09482a6588025e9f133a338d99474e8dd3c3dbbc4c5282a4fffe5a0e", size = 152624, upload-time = "2026-04-28T08:38:31.886Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
 ]
 
 [[package]]
@@ -4235,14 +4236,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.1"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
@@ -4864,7 +4865,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -4872,9 +4873,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]
@@ -4936,7 +4937,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -4944,9 +4945,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]
@@ -5365,17 +5366,58 @@ wheels = [
 name = "zarr"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "python_full_version < '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.12'" },
+    { name = "numcodecs", marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/5a/b8a0cf39a14c770c30bd1f2d120c54000c8cd9e84e8e79f38d9a7ce58071/zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb", size = 386531, upload-time = "2026-03-23T17:25:18.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e", size = 295655, upload-time = "2026-03-23T17:25:17.189Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.15' and sys_platform == 'linux'",
+    "python_full_version == '3.14.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "donfig", marker = "python_full_version >= '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.12'" },
+    { name = "numcodecs", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/27/8f391a4304f503ab6f4df6e1724380ea2e35e78a5d1ba973ba2b1347df5b/zarr-3.2.0.tar.gz", hash = "sha256:5867fa8dd7910541075531368c8eaa6f35957ab5413c68c168830e83948665ed", size = 454948, upload-time = "2026-04-30T22:18:03.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/9e/2e99d08824f300046eba83b480d6be17f771f57eed80dd7c162381cbe4de/zarr-3.2.0-py3-none-any.whl", hash = "sha256:c693bd4ae24328f242e47e9e1ced221e919d9f62cad71030fd059e398320e555", size = 318784, upload-time = "2026-04-30T22:18:01.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds the PyG implementation of the electrostatics package (`LinearQeq` + `ElectrostaticPotential`) and the QET model, with backend-conditional public re-exports under `matgl.electrostatics` and `matgl.models`.
- Refactors QET DGL as a subclass of TensorNet DGL (and exposes a matching subclass hook on TensorNet PyG) so both backends share the embedding / interaction / decomposition stack instead of duplicating it.
- Adds DGL<->PyG numerical-parity tests at three levels: per-module (electrostatics), single forward (QET), and a full 10-epoch training trajectory parity (QET).

## What's in here

- `src/matgl/electrostatics/_fast_qeq_pyg.py`, `_elec_pot_pyg.py` (new). Closed-form QEq + Coulomb-with-Gaussian-smear, scattering edge messages to the source node to match the DGL physics convention.
- `src/matgl/electrostatics/__init__.py` — backend-conditional re-export of `LinearQeq` / `ElectrostaticPotential`.
- `src/matgl/models/_tensornet_dgl.py`, `_tensornet_pyg.py` — extract `forward_features()` and `_build_readout()` as override hooks for subclasses (no behavior change to TensorNet itself).
- `src/matgl/models/_qet_dgl.py` — rewritten as `class QET(TensorNet)`. Reuses the inherited stack via `forward_features()`; QET-specific charge / electrostatic / readout heads remain. Deferred `reset_parameters()` via a sentinel keeps the random init order bit-identical to the pre-refactor implementation, so existing `QET-PES-MatQ` checkpoints and the strict `atol=1e-4` regression in `test_qet_dgl.py` still pass.
- `src/matgl/models/_qet_pyg.py` (new) — `class QET(TensorNet)` for PyG, simplified compared to the DGL version (no RNG-alignment dance) since there are no PyG QET checkpoints in the wild yet.
- `src/matgl/models/__init__.py` — export `QET` on the PyG branch.

## Tests

- `tests/electrostatics/test_fast_qeq.py`, `test_elec_pot.py`: PyG-only correctness checks (analytic 2-atom QEq, batch charge conservation, `q_ref` override, hand-computed Coulomb, gradient flow with symmetry) plus DGL<->PyG numerical-parity tests that auto-skip when DGL is not importable.
- `tests/models/test_qet_pyg.py`: forward across activations + save/load + SO(3) variant; `return_features` / `include_magmom` / `is_hardness_envs` shape contracts; DGL<->PyG single-forward parity (\`atol=1e-4\`); and a 10-epoch DGL<->PyG training-trajectory parity test (max |dE|, |dF| < 1e-6) on a 5-structure MoS toy dataset built from the conftest `MoS` fixture.
- DGL backend: `tests/models/test_tensornet_dgl.py` and `tests/models/test_qet_dgl.py` both still green, including the strict regression values.
- End-to-end smoke check: loaded the pretrained `materialyze/QET-PES-MatQ` checkpoint under both `main` and `qet_pyg` and confirmed bit-identical predictions on a Mo-S structure (|delta| = 0.000).

## Test plan

- [ ] CI runs the PyG suite and parity tests skip cleanly when DGL is unavailable
- [ ] CI runs the DGL backend with the macOS pin recipe (numpy<2, dgl 2.2.0, torch 2.3.0, torchdata<=0.8.0) and exercises the parity tests end-to-end
- [ ] Manually verified that loading `QET-PES-MatQ` under both branches yields identical energies on a Mo-S structure

## Notes

- PyG `Potential` wrapper plumbing for `total_charge` / `ext_pot` / `calc_charge` is **not** in this PR. Currently QET PyG is callable directly (and via the parity tests we exercise it with autograd through positions), but the standard `matgl.apps.pes.Potential` + ASE `PESCalculator` integration on the PyG side is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)