### PR TITLE
Add per-epoch prediction saving to PotentialLightningModule

### DIFF
--- a/src/matgl/utils/__init__.py
+++ b/src/matgl/utils/__init__.py
@@ -1,1 +1,7 @@
 """Various utility methods and classes."""
+
+from __future__ import annotations
+
+from matgl.utils.callbacks import PredictionLogger, add_sample_indices
+
+__all__ = ["PredictionLogger", "add_sample_indices"]

--- a/src/matgl/utils/_training_dgl.py
+++ b/src/matgl/utils/_training_dgl.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import lightning as pl
 import torch
 import torch.nn.functional as F
+from pathlib import Path
 import torchmetrics
 from torch import nn
 
@@ -289,6 +290,10 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         sync_dist: bool = False,
         allow_missing_labels: bool = False,
         magmom_target: Literal["absolute", "symbreak"] | None = "absolute",
+        save_predictions: bool = False,
+        save_forces: bool = False,
+        save_train_predictions: bool = False,
+        prediction_save_dir: str | Path = "predictions",
         **kwargs,
     ):
         """Init PotentialLightningModule with key parameters.
@@ -316,6 +321,10 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
                 These should be present in the dataset as torch.nans and will be skipped in computing the loss.
             magmom_target: Whether to predict the absolute site-wise value of magmoms or adapt the loss function
                 to predict the signed value breaking symmetry. If None given the loss function will be adapted.
+            save_predictions: If True, save per-epoch predicted energies (and optionally forces) to disk.
+            save_forces: If True, also save per-atom force predictions each epoch (requires save_predictions=True).
+            save_train_predictions: If True, also save training-set predictions each epoch.
+            prediction_save_dir: Directory for saved prediction .pt files. Defaults to "predictions".
             **kwargs: Passthrough to parent init.
         """
         assert energy_weight >= 0, f"energy_weight has to be >=0. Got {energy_weight}!"
@@ -365,6 +374,13 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
+        self.save_predictions = save_predictions
+        self.save_forces = save_forces
+        self.save_train_predictions = save_train_predictions
+        self.prediction_save_dir = str(prediction_save_dir)
+        self._raw_predictions: dict | None = None
+        self._val_indices_saved = False
+        self._train_indices_saved = False
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -459,7 +475,98 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         )
         batch_size = preds[0].numel()
 
+        if self._raw_predictions is not None:
+            self._raw_predictions["energies_pred"].append(e.detach().cpu())
+            self._raw_predictions["num_atoms"].append(num_atoms.detach().cpu())
+            if self.save_forces:
+                self._raw_predictions["forces_pred"].append(f.detach().cpu())
+
         return results, batch_size
+
+    def on_train_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of each training epoch."""
+        if self.save_predictions and self.save_train_predictions:
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_train_epoch_end(self) -> None:
+        """Save training predictions (if enabled) then step the LR scheduler."""
+        if self._raw_predictions is not None:
+            save_dir = Path(self.prediction_save_dir)
+            save_dir.mkdir(parents=True, exist_ok=True)
+            if not self._train_indices_saved:
+                dataset = self.trainer.train_dataloader.dataset
+                if hasattr(dataset, "indices"):
+                    torch.save(torch.tensor(dataset.indices), save_dir / "train_indices.pt")
+                torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "train_num_atoms.pt")
+                self._train_indices_saved = True
+            data: dict[str, torch.Tensor] = {
+                "energies_pred": torch.cat(self._raw_predictions["energies_pred"])
+            }
+            if self.save_forces:
+                data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+            torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_train.pt")
+            self._raw_predictions = None
+        super().on_train_epoch_end()
+
+    def on_validation_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of each validation epoch (skips sanity check)."""
+        if self.save_predictions and not self.trainer.sanity_checking:
+            if isinstance(self.trainer.val_dataloaders, (list, tuple)) and len(self.trainer.val_dataloaders) > 1:
+                raise ValueError(
+                    "save_predictions=True does not support multiple validation dataloaders. "
+                    "Pass a single val dataloader to trainer.fit()."
+                )
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_validation_epoch_end(self) -> None:
+        """Save predicted energies (and forces if save_forces=True); write val indices and num_atoms once."""
+        if self._raw_predictions is None:
+            return
+        save_dir = Path(self.prediction_save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+        if not self._val_indices_saved:
+            val_dl = self.trainer.val_dataloaders
+            if isinstance(val_dl, (list, tuple)):
+                val_dl = val_dl[0]
+            dataset = val_dl.dataset
+            if hasattr(dataset, "indices"):
+                torch.save(torch.tensor(dataset.indices), save_dir / "val_indices.pt")
+            torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "val_num_atoms.pt")
+            self._val_indices_saved = True
+        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
+        if self.save_forces:
+            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_val.pt")
+        self._raw_predictions = None
+
+    def on_test_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of the test epoch."""
+        if self.save_predictions:
+            if isinstance(self.trainer.test_dataloaders, (list, tuple)) and len(self.trainer.test_dataloaders) > 1:
+                raise ValueError(
+                    "save_predictions=True does not support multiple test dataloaders. "
+                    "Pass a single test dataloader to trainer.test()."
+                )
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_test_epoch_end(self) -> None:
+        """Save predicted energies (and forces if save_forces=True) for the test split."""
+        if self._raw_predictions is None:
+            return
+        save_dir = Path(self.prediction_save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+        test_dl = self.trainer.test_dataloaders
+        if isinstance(test_dl, (list, tuple)):
+            test_dl = test_dl[0]
+        dataset = test_dl.dataset
+        if hasattr(dataset, "indices"):
+            torch.save(torch.tensor(dataset.indices), save_dir / "test_indices.pt")
+        torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "test_num_atoms.pt")
+        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
+        if self.save_forces:
+            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_test.pt")
+        self._raw_predictions = None
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_dgl.py
+++ b/src/matgl/utils/_training_dgl.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import lightning as pl
 import torch
 import torch.nn.functional as F
-from pathlib import Path
 import torchmetrics
 from torch import nn
 
@@ -290,10 +289,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         sync_dist: bool = False,
         allow_missing_labels: bool = False,
         magmom_target: Literal["absolute", "symbreak"] | None = "absolute",
-        save_predictions: bool = False,
-        save_forces: bool = False,
-        save_train_predictions: bool = False,
-        prediction_save_dir: str | Path = "predictions",
         **kwargs,
     ):
         """Init PotentialLightningModule with key parameters.
@@ -321,10 +316,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
                 These should be present in the dataset as torch.nans and will be skipped in computing the loss.
             magmom_target: Whether to predict the absolute site-wise value of magmoms or adapt the loss function
                 to predict the signed value breaking symmetry. If None given the loss function will be adapted.
-            save_predictions: If True, save per-epoch predicted energies (and optionally forces) to disk.
-            save_forces: If True, also save per-atom force predictions each epoch (requires save_predictions=True).
-            save_train_predictions: If True, also save training-set predictions each epoch.
-            prediction_save_dir: Directory for saved prediction .pt files. Defaults to "predictions".
             **kwargs: Passthrough to parent init.
         """
         assert energy_weight >= 0, f"energy_weight has to be >=0. Got {energy_weight}!"
@@ -374,13 +365,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
-        self.save_predictions = save_predictions
-        self.save_forces = save_forces
-        self.save_train_predictions = save_train_predictions
-        self.prediction_save_dir = str(prediction_save_dir)
-        self._raw_predictions: dict | None = None
-        self._val_indices_saved = False
-        self._train_indices_saved = False
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -474,99 +458,19 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
             num_atoms=num_atoms,
         )
         batch_size = preds[0].numel()
-
-        if self._raw_predictions is not None:
-            self._raw_predictions["energies_pred"].append(e.detach().cpu())
-            self._raw_predictions["num_atoms"].append(num_atoms.detach().cpu())
-            if self.save_forces:
-                self._raw_predictions["forces_pred"].append(f.detach().cpu())
-
+        sample_idx: torch.Tensor | None = None
+        if "sample_idx" in g.ndata:
+            offsets = torch.cumsum(num_atoms, dim=0) - num_atoms
+            sample_idx = g.ndata["sample_idx"][offsets].to(torch.long).detach().cpu()
+        self._step_output = {
+            "energies_pred": preds[0].detach().cpu(),
+            "forces_pred": preds[1].detach().cpu(),
+            "energies_true": labels[0].detach().cpu(),
+            "forces_true": labels[1].detach().cpu(),
+            "num_atoms": num_atoms.detach().cpu(),
+            "sample_idx": sample_idx,
+        }
         return results, batch_size
-
-    def on_train_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of each training epoch."""
-        if self.save_predictions and self.save_train_predictions:
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_train_epoch_end(self) -> None:
-        """Save training predictions (if enabled) then step the LR scheduler."""
-        if self._raw_predictions is not None:
-            save_dir = Path(self.prediction_save_dir)
-            save_dir.mkdir(parents=True, exist_ok=True)
-            if not self._train_indices_saved:
-                dataset = self.trainer.train_dataloader.dataset
-                if hasattr(dataset, "indices"):
-                    torch.save(torch.tensor(dataset.indices), save_dir / "train_indices.pt")
-                torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "train_num_atoms.pt")
-                self._train_indices_saved = True
-            data: dict[str, torch.Tensor] = {
-                "energies_pred": torch.cat(self._raw_predictions["energies_pred"])
-            }
-            if self.save_forces:
-                data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-            torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_train.pt")
-            self._raw_predictions = None
-        super().on_train_epoch_end()
-
-    def on_validation_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of each validation epoch (skips sanity check)."""
-        if self.save_predictions and not self.trainer.sanity_checking:
-            if isinstance(self.trainer.val_dataloaders, (list, tuple)) and len(self.trainer.val_dataloaders) > 1:
-                raise ValueError(
-                    "save_predictions=True does not support multiple validation dataloaders. "
-                    "Pass a single val dataloader to trainer.fit()."
-                )
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_validation_epoch_end(self) -> None:
-        """Save predicted energies (and forces if save_forces=True); write val indices and num_atoms once."""
-        if self._raw_predictions is None:
-            return
-        save_dir = Path(self.prediction_save_dir)
-        save_dir.mkdir(parents=True, exist_ok=True)
-        if not self._val_indices_saved:
-            val_dl = self.trainer.val_dataloaders
-            if isinstance(val_dl, (list, tuple)):
-                val_dl = val_dl[0]
-            dataset = val_dl.dataset
-            if hasattr(dataset, "indices"):
-                torch.save(torch.tensor(dataset.indices), save_dir / "val_indices.pt")
-            torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "val_num_atoms.pt")
-            self._val_indices_saved = True
-        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
-        if self.save_forces:
-            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_val.pt")
-        self._raw_predictions = None
-
-    def on_test_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of the test epoch."""
-        if self.save_predictions:
-            if isinstance(self.trainer.test_dataloaders, (list, tuple)) and len(self.trainer.test_dataloaders) > 1:
-                raise ValueError(
-                    "save_predictions=True does not support multiple test dataloaders. "
-                    "Pass a single test dataloader to trainer.test()."
-                )
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_test_epoch_end(self) -> None:
-        """Save predicted energies (and forces if save_forces=True) for the test split."""
-        if self._raw_predictions is None:
-            return
-        save_dir = Path(self.prediction_save_dir)
-        save_dir.mkdir(parents=True, exist_ok=True)
-        test_dl = self.trainer.test_dataloaders
-        if isinstance(test_dl, (list, tuple)):
-            test_dl = test_dl[0]
-        dataset = test_dl.dataset
-        if hasattr(dataset, "indices"):
-            torch.save(torch.tensor(dataset.indices), save_dir / "test_indices.pt")
-        torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "test_num_atoms.pt")
-        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
-        if self.save_forces:
-            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_test.pt")
-        self._raw_predictions = None
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_pyg.py
+++ b/src/matgl/utils/_training_pyg.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import lightning as pl
 import torch
 import torch.nn.functional as F
-from pathlib import Path
 import torchmetrics
 from torch import nn
 
@@ -305,10 +304,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         sync_dist: bool = False,
         allow_missing_labels: bool = False,
         magmom_target: Literal["absolute", "symbreak"] | None = "absolute",
-        save_predictions: bool = False,
-        save_forces: bool = False,
-        save_train_predictions: bool = False,
-        prediction_save_dir: str | Path = "predictions",
         **kwargs,
     ):
         """Init PotentialLightningModule with key parameters.
@@ -336,10 +331,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
                 These should be present in the dataset as torch.nans and will be skipped in computing the loss.
             magmom_target: Whether to predict the absolute site-wise value of magmoms or adapt the loss function
                 to predict the signed value breaking symmetry. If None given the loss function will be adapted.
-            save_predictions: If True, save per-epoch predicted energies (and optionally forces) to disk.
-            save_forces: If True, also save per-atom force predictions each epoch (requires save_predictions=True).
-            save_train_predictions: If True, also save training-set predictions each epoch.
-            prediction_save_dir: Directory for saved prediction .pt files. Defaults to "predictions".
             **kwargs: Passthrough to parent init.
         """
         assert energy_weight >= 0, f"energy_weight has to be >=0. Got {energy_weight}!"
@@ -388,13 +379,6 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
-        self.save_predictions = save_predictions
-        self.save_forces = save_forces
-        self.save_train_predictions = save_train_predictions
-        self.prediction_save_dir = str(prediction_save_dir)
-        self._raw_predictions: dict | None = None
-        self._val_indices_saved = False
-        self._train_indices_saved = False
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -487,99 +471,18 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
             num_atoms=num_atoms,
         )
         batch_size = preds[0].numel()
-
-        if self._raw_predictions is not None:
-            self._raw_predictions["energies_pred"].append(e.detach().cpu())
-            self._raw_predictions["num_atoms"].append(num_atoms.detach().cpu())
-            if self.save_forces:
-                self._raw_predictions["forces_pred"].append(f.detach().cpu())
-
+        sample_idx = getattr(g, "sample_idx", None)
+        if sample_idx is not None:
+            sample_idx = sample_idx.to(torch.long).detach().cpu()
+        self._step_output = {
+            "energies_pred": preds[0].detach().cpu(),
+            "forces_pred": preds[1].detach().cpu(),
+            "energies_true": labels[0].detach().cpu(),
+            "forces_true": labels[1].detach().cpu(),
+            "num_atoms": num_atoms.detach().cpu(),
+            "sample_idx": sample_idx,
+        }
         return results, batch_size
-
-    def on_train_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of each training epoch."""
-        if self.save_predictions and self.save_train_predictions:
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_train_epoch_end(self) -> None:
-        """Save training predictions (if enabled) then step the LR scheduler."""
-        if self._raw_predictions is not None:
-            save_dir = Path(self.prediction_save_dir)
-            save_dir.mkdir(parents=True, exist_ok=True)
-            if not self._train_indices_saved:
-                dataset = self.trainer.train_dataloader.dataset
-                if hasattr(dataset, "indices"):
-                    torch.save(torch.tensor(dataset.indices), save_dir / "train_indices.pt")
-                torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "train_num_atoms.pt")
-                self._train_indices_saved = True
-            data: dict[str, torch.Tensor] = {
-                "energies_pred": torch.cat(self._raw_predictions["energies_pred"])
-            }
-            if self.save_forces:
-                data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-            torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_train.pt")
-            self._raw_predictions = None
-        super().on_train_epoch_end()
-
-    def on_validation_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of each validation epoch (skips sanity check)."""
-        if self.save_predictions and not self.trainer.sanity_checking:
-            if isinstance(self.trainer.val_dataloaders, (list, tuple)) and len(self.trainer.val_dataloaders) > 1:
-                raise ValueError(
-                    "save_predictions=True does not support multiple validation dataloaders. "
-                    "Pass a single val dataloader to trainer.fit()."
-                )
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_validation_epoch_end(self) -> None:
-        """Save predicted energies (and forces if save_forces=True); write val indices and num_atoms once."""
-        if self._raw_predictions is None:
-            return
-        save_dir = Path(self.prediction_save_dir)
-        save_dir.mkdir(parents=True, exist_ok=True)
-        if not self._val_indices_saved:
-            val_dl = self.trainer.val_dataloaders
-            if isinstance(val_dl, (list, tuple)):
-                val_dl = val_dl[0]
-            dataset = val_dl.dataset
-            if hasattr(dataset, "indices"):
-                torch.save(torch.tensor(dataset.indices), save_dir / "val_indices.pt")
-            torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "val_num_atoms.pt")
-            self._val_indices_saved = True
-        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
-        if self.save_forces:
-            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_val.pt")
-        self._raw_predictions = None
-
-    def on_test_epoch_start(self) -> None:
-        """Initialise prediction buffer at the start of the test epoch."""
-        if self.save_predictions:
-            if isinstance(self.trainer.test_dataloaders, (list, tuple)) and len(self.trainer.test_dataloaders) > 1:
-                raise ValueError(
-                    "save_predictions=True does not support multiple test dataloaders. "
-                    "Pass a single test dataloader to trainer.test()."
-                )
-            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
-
-    def on_test_epoch_end(self) -> None:
-        """Save predicted energies (and forces if save_forces=True) for the test split."""
-        if self._raw_predictions is None:
-            return
-        save_dir = Path(self.prediction_save_dir)
-        save_dir.mkdir(parents=True, exist_ok=True)
-        test_dl = self.trainer.test_dataloaders
-        if isinstance(test_dl, (list, tuple)):
-            test_dl = test_dl[0]
-        dataset = test_dl.dataset
-        if hasattr(dataset, "indices"):
-            torch.save(torch.tensor(dataset.indices), save_dir / "test_indices.pt")
-        torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "test_num_atoms.pt")
-        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
-        if self.save_forces:
-            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
-        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_test.pt")
-        self._raw_predictions = None
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_pyg.py
+++ b/src/matgl/utils/_training_pyg.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import lightning as pl
 import torch
 import torch.nn.functional as F
+from pathlib import Path
 import torchmetrics
 from torch import nn
 
@@ -304,6 +305,10 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         sync_dist: bool = False,
         allow_missing_labels: bool = False,
         magmom_target: Literal["absolute", "symbreak"] | None = "absolute",
+        save_predictions: bool = False,
+        save_forces: bool = False,
+        save_train_predictions: bool = False,
+        prediction_save_dir: str | Path = "predictions",
         **kwargs,
     ):
         """Init PotentialLightningModule with key parameters.
@@ -331,6 +336,10 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
                 These should be present in the dataset as torch.nans and will be skipped in computing the loss.
             magmom_target: Whether to predict the absolute site-wise value of magmoms or adapt the loss function
                 to predict the signed value breaking symmetry. If None given the loss function will be adapted.
+            save_predictions: If True, save per-epoch predicted energies (and optionally forces) to disk.
+            save_forces: If True, also save per-atom force predictions each epoch (requires save_predictions=True).
+            save_train_predictions: If True, also save training-set predictions each epoch.
+            prediction_save_dir: Directory for saved prediction .pt files. Defaults to "predictions".
             **kwargs: Passthrough to parent init.
         """
         assert energy_weight >= 0, f"energy_weight has to be >=0. Got {energy_weight}!"
@@ -379,6 +388,13 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
+        self.save_predictions = save_predictions
+        self.save_forces = save_forces
+        self.save_train_predictions = save_train_predictions
+        self.prediction_save_dir = str(prediction_save_dir)
+        self._raw_predictions: dict | None = None
+        self._val_indices_saved = False
+        self._train_indices_saved = False
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -472,7 +488,98 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         )
         batch_size = preds[0].numel()
 
+        if self._raw_predictions is not None:
+            self._raw_predictions["energies_pred"].append(e.detach().cpu())
+            self._raw_predictions["num_atoms"].append(num_atoms.detach().cpu())
+            if self.save_forces:
+                self._raw_predictions["forces_pred"].append(f.detach().cpu())
+
         return results, batch_size
+
+    def on_train_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of each training epoch."""
+        if self.save_predictions and self.save_train_predictions:
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_train_epoch_end(self) -> None:
+        """Save training predictions (if enabled) then step the LR scheduler."""
+        if self._raw_predictions is not None:
+            save_dir = Path(self.prediction_save_dir)
+            save_dir.mkdir(parents=True, exist_ok=True)
+            if not self._train_indices_saved:
+                dataset = self.trainer.train_dataloader.dataset
+                if hasattr(dataset, "indices"):
+                    torch.save(torch.tensor(dataset.indices), save_dir / "train_indices.pt")
+                torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "train_num_atoms.pt")
+                self._train_indices_saved = True
+            data: dict[str, torch.Tensor] = {
+                "energies_pred": torch.cat(self._raw_predictions["energies_pred"])
+            }
+            if self.save_forces:
+                data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+            torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_train.pt")
+            self._raw_predictions = None
+        super().on_train_epoch_end()
+
+    def on_validation_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of each validation epoch (skips sanity check)."""
+        if self.save_predictions and not self.trainer.sanity_checking:
+            if isinstance(self.trainer.val_dataloaders, (list, tuple)) and len(self.trainer.val_dataloaders) > 1:
+                raise ValueError(
+                    "save_predictions=True does not support multiple validation dataloaders. "
+                    "Pass a single val dataloader to trainer.fit()."
+                )
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_validation_epoch_end(self) -> None:
+        """Save predicted energies (and forces if save_forces=True); write val indices and num_atoms once."""
+        if self._raw_predictions is None:
+            return
+        save_dir = Path(self.prediction_save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+        if not self._val_indices_saved:
+            val_dl = self.trainer.val_dataloaders
+            if isinstance(val_dl, (list, tuple)):
+                val_dl = val_dl[0]
+            dataset = val_dl.dataset
+            if hasattr(dataset, "indices"):
+                torch.save(torch.tensor(dataset.indices), save_dir / "val_indices.pt")
+            torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "val_num_atoms.pt")
+            self._val_indices_saved = True
+        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
+        if self.save_forces:
+            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_val.pt")
+        self._raw_predictions = None
+
+    def on_test_epoch_start(self) -> None:
+        """Initialise prediction buffer at the start of the test epoch."""
+        if self.save_predictions:
+            if isinstance(self.trainer.test_dataloaders, (list, tuple)) and len(self.trainer.test_dataloaders) > 1:
+                raise ValueError(
+                    "save_predictions=True does not support multiple test dataloaders. "
+                    "Pass a single test dataloader to trainer.test()."
+                )
+            self._raw_predictions = {"energies_pred": [], "num_atoms": [], "forces_pred": []}
+
+    def on_test_epoch_end(self) -> None:
+        """Save predicted energies (and forces if save_forces=True) for the test split."""
+        if self._raw_predictions is None:
+            return
+        save_dir = Path(self.prediction_save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+        test_dl = self.trainer.test_dataloaders
+        if isinstance(test_dl, (list, tuple)):
+            test_dl = test_dl[0]
+        dataset = test_dl.dataset
+        if hasattr(dataset, "indices"):
+            torch.save(torch.tensor(dataset.indices), save_dir / "test_indices.pt")
+        torch.save(torch.cat(self._raw_predictions["num_atoms"]), save_dir / "test_num_atoms.pt")
+        data = {"energies_pred": torch.cat(self._raw_predictions["energies_pred"])}
+        if self.save_forces:
+            data["forces_pred"] = torch.cat(self._raw_predictions["forces_pred"])
+        torch.save(data, save_dir / f"epoch={self.trainer.current_epoch:04d}_test.pt")
+        self._raw_predictions = None
 
     def loss_fn(
         self,

--- a/src/matgl/utils/callbacks.py
+++ b/src/matgl/utils/callbacks.py
@@ -1,0 +1,320 @@
+"""Lightning callbacks for matgl training."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import lightning as pl
+import torch
+
+import matgl
+
+
+def add_sample_indices(dataset: Any, start: int = 0) -> None:
+    """Stamp a unique global index onto every sample's graph in ``dataset``.
+
+    The index is what :class:`PredictionLogger` uses to keep per-epoch logs sorted under a
+    shuffled training dataloader: column ``k`` of the saved energy / force arrays is always
+    the prediction for the configuration whose stamped index is ``k``.
+
+    For PYG, the index is stored as ``data.sample_idx`` (a ``(1,)`` long tensor) on each
+    underlying ``torch_geometric.data.Data`` graph. ``Batch.from_data_list`` then collates
+    it automatically into a ``(B,)`` tensor on the batched ``Batch``.
+
+    For DGL, the index is replicated per-atom into ``g.ndata["sample_idx"]``. ``dgl.batch``
+    concatenates ``ndata`` so the per-graph index can be recovered downstream from the
+    batch boundaries given by ``g.batch_num_nodes()``.
+
+    Works with both raw ``MGLDataset`` instances and ``torch.utils.data.Subset`` /
+    ``dgl.data.utils.Subset`` returned by ``split_dataset``. Mutation is in-place: indices
+    are written onto the shared underlying graph objects, so call this after splitting and
+    only on the subset(s) you want logged.
+
+    Args:
+        dataset: An iterable that yields ``(graph, ...)`` tuples — typically an MGLDataset
+            or a Subset thereof.
+        start: First index to assign. Defaults to 0.
+    """
+    for k, item in enumerate(dataset):
+        graph = item[0]
+        idx = start + k
+        if matgl.config.BACKEND == "PYG":
+            graph.sample_idx = torch.tensor([idx], dtype=torch.long)
+        else:
+            graph.ndata["sample_idx"] = torch.full((graph.num_nodes(),), idx, dtype=torch.long)
+
+
+class PredictionLogger(pl.Callback):
+    """Lightning callback that logs per-epoch energy (and optionally force) predictions to disk.
+
+    At the end of each validation epoch the callback overwrites a single ``val_predictions.pt``
+    file containing all epochs seen so far, so the file is always recoverable after a walltime
+    cut.  An analogous ``train_predictions.pt`` is written when ``log_train=True``, and a
+    ``test_predictions.pt`` is written once when ``trainer.test()`` is called.
+
+    The dataset(s) being logged must be stamped with global indices via
+    :func:`add_sample_indices` before training so that column ``k`` of the saved arrays
+    always refers to the same sample, even with a shuffled training dataloader. Without
+    indices the callback raises at the first batch end.
+
+    The saved dict has the following keys (force keys only present when ``log_forces=True``):
+
+    .. code-block:: text
+
+        {
+            "energy_pred":  (n_epochs, n_structures)   # predicted energies per epoch
+            "energy_true":  (n_structures,)             # DFT reference energies (fixed)
+            "num_atoms":    (n_structures,)             # atoms per structure (fixed)
+            "force_pred":   (n_epochs, total_atoms, 3) # predicted forces per epoch
+            "force_true":   (total_atoms, 3)            # DFT reference forces (fixed)
+        }
+
+    Example::
+
+        from matgl.utils.callbacks import PredictionLogger, add_sample_indices
+
+        add_sample_indices(val_data)
+        logger = PredictionLogger("predictions/", log_forces=True)
+        trainer = pl.Trainer(callbacks=[logger], ...)
+        trainer.fit(lit_model, train_loader, val_loader)
+
+    Args:
+        save_dir: Directory where prediction files are written.
+        log_train: If True, also log training-set predictions each epoch.
+        log_forces: If True, also log per-atom force predictions and ground truth.
+    """
+
+    def __init__(
+        self,
+        save_dir: str | Path,
+        log_train: bool = False,
+        log_forces: bool = False,
+    ) -> None:
+        """Initialise PredictionLogger."""
+        super().__init__()
+        self.save_dir = Path(save_dir)
+        self.log_train = log_train
+        self.log_forces = log_forces
+
+        # current-epoch buffers: idx -> {e_pred, e_true, num_atoms, f_pred?, f_true?}
+        self._val_buf: dict[int, dict[str, torch.Tensor]] = {}
+        self._train_buf: dict[int, dict[str, torch.Tensor]] = {}
+        self._test_buf: dict[int, dict[str, torch.Tensor]] = {}
+
+        # accumulated across all epochs (stacked sorted-by-idx tensors)
+        self._val_e_pred: list[torch.Tensor] = []
+        self._val_f_pred: list[torch.Tensor] = []
+        self._train_e_pred: list[torch.Tensor] = []
+        self._train_f_pred: list[torch.Tensor] = []
+
+        # ground truth + num_atoms (set once, from first epoch)
+        self._val_e_true: torch.Tensor | None = None
+        self._val_f_true: torch.Tensor | None = None
+        self._val_num_atoms: torch.Tensor | None = None
+        self._train_e_true: torch.Tensor | None = None
+        self._train_f_true: torch.Tensor | None = None
+        self._train_num_atoms: torch.Tensor | None = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _absorb(self, pl_module: Any, buf: dict[int, dict[str, torch.Tensor]]) -> None:
+        """Capture per-sample preds from the latest step and stash by sample idx."""
+        out = getattr(pl_module, "_step_output", None)
+        if out is None:
+            return
+        sample_idx = out.get("sample_idx")
+        if sample_idx is None:
+            raise RuntimeError(
+                "PredictionLogger could not find per-sample indices on the batch. Call "
+                "`matgl.utils.callbacks.add_sample_indices(dataset)` on the dataset (or its "
+                "subset) you are logging before constructing the dataloader."
+            )
+        e_pred = out["energies_pred"]
+        e_true = out["energies_true"]
+        num_atoms = out["num_atoms"]
+        f_pred = out["forces_pred"] if self.log_forces else None
+        f_true = out["forces_true"] if self.log_forces else None
+        offset = 0
+        for i, (idx, n) in enumerate(zip(sample_idx.tolist(), num_atoms.tolist(), strict=False)):
+            entry: dict[str, torch.Tensor] = {
+                "e_pred": e_pred[i].reshape(()),
+                "e_true": e_true[i].reshape(()),
+                "num_atoms": torch.tensor(int(n), dtype=torch.long),
+            }
+            if self.log_forces and f_pred is not None and f_true is not None:
+                entry["f_pred"] = f_pred[offset : offset + int(n)]
+                entry["f_true"] = f_true[offset : offset + int(n)]
+            buf[int(idx)] = entry
+            offset += int(n)
+
+    def _stack_epoch(
+        self, buf: dict[int, dict[str, torch.Tensor]]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        """Stack per-sample buffer in sorted-idx order into epoch tensors."""
+        sorted_idx = sorted(buf.keys())
+        e_pred = torch.stack([buf[i]["e_pred"] for i in sorted_idx])
+        e_true = torch.stack([buf[i]["e_true"] for i in sorted_idx])
+        num_atoms = torch.stack([buf[i]["num_atoms"] for i in sorted_idx])
+        f_pred: torch.Tensor | None = None
+        f_true: torch.Tensor | None = None
+        if self.log_forces:
+            f_pred = torch.cat([buf[i]["f_pred"] for i in sorted_idx], dim=0)
+            f_true = torch.cat([buf[i]["f_true"] for i in sorted_idx], dim=0)
+        return e_pred, e_true, num_atoms, f_pred, f_true
+
+    def _save(self, path: Path, payload: dict) -> None:
+        """Write payload to ``path``, creating parent dirs if needed."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(payload, path)
+
+    # ------------------------------------------------------------------
+    # fit_start — validate configuration
+    # ------------------------------------------------------------------
+
+    def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Raise early if multiple val dataloaders are configured."""
+        val_dls = trainer.val_dataloaders
+        if isinstance(val_dls, (list, tuple)) and len(val_dls) > 1:
+            raise ValueError(
+                "PredictionLogger does not support multiple validation dataloaders. "
+                "Pass a single val dataloader to trainer.fit()."
+            )
+
+    # ------------------------------------------------------------------
+    # validation
+    # ------------------------------------------------------------------
+
+    def on_validation_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Reset val buffer at the start of each validation epoch."""
+        if not trainer.sanity_checking:
+            self._val_buf = {}
+
+    def on_validation_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Accumulate predictions from each validation batch."""
+        if not trainer.sanity_checking:
+            self._absorb(pl_module, self._val_buf)
+
+    def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Stack and save val predictions, overwriting the file each epoch."""
+        if trainer.sanity_checking or not self._val_buf:
+            return
+        e_pred, e_true, num_atoms, f_pred, f_true = self._stack_epoch(self._val_buf)
+        self._val_e_pred.append(e_pred)
+        if self._val_e_true is None:
+            self._val_e_true = e_true
+            self._val_num_atoms = num_atoms
+        if self.log_forces and f_pred is not None and f_true is not None:
+            self._val_f_pred.append(f_pred)
+            if self._val_f_true is None:
+                self._val_f_true = f_true
+
+        assert self._val_e_true is not None
+        assert self._val_num_atoms is not None
+        payload: dict[str, torch.Tensor] = {
+            "energy_pred": torch.stack(self._val_e_pred),
+            "energy_true": self._val_e_true,
+            "num_atoms": self._val_num_atoms,
+        }
+        if self.log_forces and self._val_f_true is not None:
+            payload["force_pred"] = torch.stack(self._val_f_pred)
+            payload["force_true"] = self._val_f_true
+        self._save(self.save_dir / "val_predictions.pt", payload)
+
+    # ------------------------------------------------------------------
+    # training
+    # ------------------------------------------------------------------
+
+    def on_train_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Reset train buffer at the start of each training epoch."""
+        if self.log_train:
+            self._train_buf = {}
+
+    def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        """Accumulate predictions from each training batch."""
+        if self.log_train:
+            self._absorb(pl_module, self._train_buf)
+
+    def on_train_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Stack and save train predictions, overwriting the file each epoch."""
+        if not self.log_train or not self._train_buf:
+            return
+        e_pred, e_true, num_atoms, f_pred, f_true = self._stack_epoch(self._train_buf)
+        self._train_e_pred.append(e_pred)
+        if self._train_e_true is None:
+            self._train_e_true = e_true
+            self._train_num_atoms = num_atoms
+        if self.log_forces and f_pred is not None and f_true is not None:
+            self._train_f_pred.append(f_pred)
+            if self._train_f_true is None:
+                self._train_f_true = f_true
+
+        assert self._train_e_true is not None
+        assert self._train_num_atoms is not None
+        payload: dict[str, torch.Tensor] = {
+            "energy_pred": torch.stack(self._train_e_pred),
+            "energy_true": self._train_e_true,
+            "num_atoms": self._train_num_atoms,
+        }
+        if self.log_forces and self._train_f_true is not None:
+            payload["force_pred"] = torch.stack(self._train_f_pred)
+            payload["force_true"] = self._train_f_true
+        self._save(self.save_dir / "train_predictions.pt", payload)
+
+    # ------------------------------------------------------------------
+    # test
+    # ------------------------------------------------------------------
+
+    def on_test_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Reset test buffer and validate single dataloader."""
+        test_dls = trainer.test_dataloaders
+        if isinstance(test_dls, (list, tuple)) and len(test_dls) > 1:
+            raise ValueError(
+                "PredictionLogger does not support multiple test dataloaders. "
+                "Pass a single test dataloader to trainer.test()."
+            )
+        self._test_buf = {}
+
+    def on_test_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Accumulate predictions from each test batch."""
+        self._absorb(pl_module, self._test_buf)
+
+    def on_test_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Save test predictions to disk."""
+        if not self._test_buf:
+            return
+        e_pred, e_true, num_atoms, f_pred, f_true = self._stack_epoch(self._test_buf)
+        payload: dict[str, torch.Tensor] = {
+            "energy_pred": e_pred,
+            "energy_true": e_true,
+            "num_atoms": num_atoms,
+        }
+        if self.log_forces and f_pred is not None and f_true is not None:
+            payload["force_pred"] = f_pred
+            payload["force_true"] = f_true
+        self._save(self.save_dir / "test_predictions.pt", payload)

--- a/tests/utils/test_training_dgl.py
+++ b/tests/utils/test_training_dgl.py
@@ -22,6 +22,7 @@ from matgl.ext._pymatgen_dgl import Structure2Graph, get_element_list
 from matgl.graph._data_dgl import MGLDataLoader, MGLDataset, collate_fn_graph, collate_fn_pes
 from matgl.models import CHGNet, M3GNet, MEGNet, SO3Net, TensorNet
 from matgl.models._qet_dgl import QET
+from matgl.utils.callbacks import PredictionLogger, add_sample_indices
 from matgl.utils.training import ModelLightningModule, PotentialLightningModule, xavier_init
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
@@ -953,3 +954,62 @@ def test_xavier_init(distribution):
         print(w)
         assert not torch.allclose(w, model.output_proj.layers[0].get_parameter("weight"))
         assert torch.allclose(torch.tensor(0.0), model.output_proj.layers[0].get_parameter("bias"))
+
+
+def test_prediction_logger(LiFePO4, BaNiO3, tmp_path):
+    structures = [LiFePO4, BaNiO3] * 5
+    energies = [-2.0, -3.0] * 5
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        structures=structures,
+        converter=converter,
+        labels={"energies": energies, "forces": forces, "stresses": stresses},
+        save_cache=False,
+    )
+    train_data, val_data, test_data = split_dataset(dataset, frac_list=[0.6, 0.2, 0.2], shuffle=True, random_state=42)
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+    add_sample_indices(test_data)
+    train_loader, val_loader, test_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        test_data=test_data,
+        collate_fn=collate_fn_pes,
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    model = M3GNet(element_types=element_types, is_intensive=False)
+    lit_model = PotentialLightningModule(model=model, stress_weight=0.0)
+    logger = PredictionLogger(tmp_path / "preds", log_train=True, log_forces=True)
+    trainer = pl.Trainer(
+        max_epochs=2,
+        accelerator=device,
+        inference_mode=False,
+        enable_progress_bar=False,
+        logger=False,
+        enable_checkpointing=False,
+        callbacks=[logger],
+    )
+    trainer.fit(lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+    trainer.test(lit_model, dataloaders=test_loader)
+
+    n_train, n_val, n_test = len(train_data), len(val_data), len(test_data)
+    val_out = torch.load(tmp_path / "preds" / "val_predictions.pt", weights_only=True)
+    assert val_out["energy_pred"].shape == (2, n_val)
+    assert val_out["energy_true"].shape == (n_val,)
+    total_val_atoms = int(val_out["num_atoms"].sum())
+    assert val_out["force_pred"].shape == (2, total_val_atoms, 3)
+    assert val_out["force_true"].shape == (total_val_atoms, 3)
+
+    train_out = torch.load(tmp_path / "preds" / "train_predictions.pt", weights_only=True)
+    assert train_out["energy_pred"].shape == (2, n_train)
+    assert train_out["energy_true"].shape == (n_train,)
+
+    test_out = torch.load(tmp_path / "preds" / "test_predictions.pt", weights_only=True)
+    assert test_out["energy_pred"].shape == (n_test,)
+
+    teardown()

--- a/tests/utils/test_training_pyg.py
+++ b/tests/utils/test_training_pyg.py
@@ -27,6 +27,7 @@ from matgl.utils._training_pyg import (
     PotentialLightningModule,
     xavier_init,
 )
+from matgl.utils.callbacks import PredictionLogger, add_sample_indices
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -348,4 +349,60 @@ def test_xavier_init(distribution):
         xavier_init(model, distribution=distribution)
         print(w)
         assert not torch.allclose(w, model.linear.get_parameter("weight"))
-        assert torch.allclose(torch.tensor(0.0), model.linear.get_parameter("bias"))
+
+
+def test_prediction_logger(LiFePO4, BaNiO3, tmp_path):
+    structures = [LiFePO4, BaNiO3] * 5
+    energies = [-2.0, -3.0] * 5
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        structures=structures,
+        converter=converter,
+        labels={"energies": energies, "forces": forces, "stresses": stresses},
+        save_cache=False,
+    )
+    train_data, val_data, test_data = split_dataset(dataset, frac_list=[0.6, 0.2, 0.2], shuffle=True, random_state=42)
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+    add_sample_indices(test_data)
+    train_loader, val_loader, test_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        test_data=test_data,
+        collate_fn=collate_fn_pes,
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    model = TensorNet(element_types=element_types, is_intensive=False, use_warp=False)
+    lit_model = PotentialLightningModule(model=model, stress_weight=0.0)
+    logger = PredictionLogger(tmp_path / "preds", log_train=True, log_forces=True)
+    trainer = pl.Trainer(
+        max_epochs=2,
+        accelerator=device,
+        inference_mode=False,
+        enable_progress_bar=False,
+        logger=False,
+        enable_checkpointing=False,
+        callbacks=[logger],
+    )
+    trainer.fit(lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+    trainer.test(lit_model, dataloaders=test_loader)
+
+    n_train, n_val, n_test = len(train_data), len(val_data), len(test_data)
+    val_out = torch.load(tmp_path / "preds" / "val_predictions.pt", weights_only=True)
+    assert val_out["energy_pred"].shape == (2, n_val)
+    assert val_out["energy_true"].shape == (n_val,)
+    total_val_atoms = int(val_out["num_atoms"].sum())
+    assert val_out["force_pred"].shape == (2, total_val_atoms, 3)
+    assert val_out["force_true"].shape == (total_val_atoms, 3)
+
+    train_out = torch.load(tmp_path / "preds" / "train_predictions.pt", weights_only=True)
+    assert train_out["energy_pred"].shape == (2, n_train)
+    assert train_out["energy_true"].shape == (n_train,)
+
+    test_out = torch.load(tmp_path / "preds" / "test_predictions.pt", weights_only=True)
+    assert test_out["energy_pred"].shape == (n_test,)


### PR DESCRIPTION
New arguments to `PotentialLightningModule` (both DGL and PyG backends):

- `save_predictions` (bool, default `False`): enable saving
- `save_forces` (bool, default `False`): also save per-atom forces
- `save_train_predictions` (bool, default `False`): also save training-set predictions
- `prediction_save_dir` (str, default `"predictions"`): output directory