### PR TITLE
Add PredictionLogger callback for per-epoch training (and val) logging

### DIFF
--- a/src/matgl/utils/_training_dgl.py
+++ b/src/matgl/utils/_training_dgl.py
@@ -50,7 +50,7 @@ class MatglLightningModuleMixin:
         sch = self.lr_schedulers()  # type: ignore[attr-defined]
         sch.step()
 
-    def validation_step(self, batch: tuple, batch_idx: int) -> torch.Tensor:
+    def validation_step(self, batch: tuple, batch_idx: int) -> Any:
         """Validation step.
 
         Args:
@@ -365,6 +365,8 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
+        self._last_preds: tuple[torch.Tensor, ...] | None = None
+        self._last_labels: tuple[torch.Tensor, ...] | None = None
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -459,7 +461,25 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         )
         batch_size = preds[0].numel()
 
+        self._last_preds = preds
+        self._last_labels = labels
+
         return results, batch_size
+
+    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Validation step that also exposes predictions/labels for callbacks.
+
+        Args:
+            batch: Data batch.
+            batch_idx: Batch index.
+
+        Returns:
+            Dict with the total ``loss`` plus the raw ``preds`` and ``labels`` tuples
+            ``(energies, forces, ...)`` from this batch, suitable for consumption by a
+            Lightning ``Callback`` (e.g. ``matgl.utils.callbacks.PredictionLogger``).
+        """
+        loss = super().validation_step(batch, batch_idx)
+        return {"loss": loss, "preds": self._last_preds, "labels": self._last_labels}
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_dgl.py
+++ b/src/matgl/utils/_training_dgl.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 class MatglLightningModuleMixin:
     """Mix-in class implementing common functions for training."""
 
-    def training_step(self, batch: tuple, batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: tuple, batch_idx: int) -> Any:
         """Training step.
 
         Args:
@@ -367,6 +367,8 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.magmom_target = magmom_target
         self._last_preds: tuple[torch.Tensor, ...] | None = None
         self._last_labels: tuple[torch.Tensor, ...] | None = None
+        self._last_indices: torch.Tensor | None = None
+        self._last_num_atoms: torch.Tensor | None = None
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -463,23 +465,57 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
 
         self._last_preds = preds
         self._last_labels = labels
+        self._last_num_atoms = num_atoms
+        if "sample_idx" in g.ndata:
+            offsets = torch.cumsum(num_atoms, dim=0) - num_atoms
+            self._last_indices = g.ndata["sample_idx"][offsets].to(torch.long)
+        else:
+            self._last_indices = None
 
         return results, batch_size
 
-    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
-        """Validation step that also exposes predictions/labels for callbacks.
+    def training_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Training step that exposes per-sample preds and labels for callbacks.
 
         Args:
             batch: Data batch.
             batch_idx: Batch index.
 
         Returns:
-            Dict with the total ``loss`` plus the raw ``preds`` and ``labels`` tuples
-            ``(energies, forces, ...)`` from this batch, suitable for consumption by a
-            Lightning ``Callback`` (e.g. ``matgl.utils.callbacks.PredictionLogger``).
+            Dict with ``loss`` (used by Lightning for backprop) plus the raw ``preds``,
+            ``labels`` tuples and per-sample ``indices`` / ``num_atoms`` so that callbacks
+            such as :class:`matgl.utils.callbacks.PredictionLogger` can place predictions in
+            a stable per-sample order across shuffled epochs.
+        """
+        loss = super().training_step(batch, batch_idx)
+        return {
+            "loss": loss,
+            "preds": self._last_preds,
+            "labels": self._last_labels,
+            "indices": self._last_indices,
+            "num_atoms": self._last_num_atoms,
+        }
+
+    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Validation step that exposes per-sample preds and labels for callbacks.
+
+        Args:
+            batch: Data batch.
+            batch_idx: Batch index.
+
+        Returns:
+            Dict with ``loss`` plus the raw ``preds``, ``labels`` tuples and per-sample
+            ``indices`` / ``num_atoms`` (the latter only present when the dataset has been
+            stamped with :func:`matgl.utils.callbacks.add_sample_indices`).
         """
         loss = super().validation_step(batch, batch_idx)
-        return {"loss": loss, "preds": self._last_preds, "labels": self._last_labels}
+        return {
+            "loss": loss,
+            "preds": self._last_preds,
+            "labels": self._last_labels,
+            "indices": self._last_indices,
+            "num_atoms": self._last_num_atoms,
+        }
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_pyg.py
+++ b/src/matgl/utils/_training_pyg.py
@@ -50,7 +50,7 @@ class MatglLightningModuleMixin:
         sch = self.lr_schedulers()  # type: ignore[attr-defined]
         sch.step()
 
-    def validation_step(self, batch: tuple, batch_idx: int) -> torch.Tensor:
+    def validation_step(self, batch: tuple, batch_idx: int) -> Any:
         """Validation step.
 
         Args:
@@ -379,6 +379,8 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.sync_dist = sync_dist
         self.allow_missing_labels = allow_missing_labels
         self.magmom_target = magmom_target
+        self._last_preds: tuple[torch.Tensor, ...] | None = None
+        self._last_labels: tuple[torch.Tensor, ...] | None = None
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -472,7 +474,25 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         )
         batch_size = preds[0].numel()
 
+        self._last_preds = preds
+        self._last_labels = labels
+
         return results, batch_size
+
+    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Validation step that also exposes predictions/labels for callbacks.
+
+        Args:
+            batch: Data batch.
+            batch_idx: Batch index.
+
+        Returns:
+            Dict with the total ``loss`` plus the raw ``preds`` and ``labels`` tuples
+            ``(energies, forces, ...)`` from this batch, suitable for consumption by a
+            Lightning ``Callback`` (e.g. ``matgl.utils.callbacks.PredictionLogger``).
+        """
+        loss = super().validation_step(batch, batch_idx)
+        return {"loss": loss, "preds": self._last_preds, "labels": self._last_labels}
 
     def loss_fn(
         self,

--- a/src/matgl/utils/_training_pyg.py
+++ b/src/matgl/utils/_training_pyg.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 class MatglLightningModuleMixin:
     """Mix-in class implementing common functions for training."""
 
-    def training_step(self, batch: tuple, batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: tuple, batch_idx: int) -> Any:
         """Training step.
 
         Args:
@@ -381,6 +381,8 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         self.magmom_target = magmom_target
         self._last_preds: tuple[torch.Tensor, ...] | None = None
         self._last_labels: tuple[torch.Tensor, ...] | None = None
+        self._last_indices: torch.Tensor | None = None
+        self._last_num_atoms: torch.Tensor | None = None
         self.save_hyperparameters(ignore=["model"])
 
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
@@ -476,23 +478,53 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
 
         self._last_preds = preds
         self._last_labels = labels
+        self._last_num_atoms = num_atoms
+        self._last_indices = getattr(g, "sample_idx", None)
 
         return results, batch_size
 
-    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
-        """Validation step that also exposes predictions/labels for callbacks.
+    def training_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Training step that exposes per-sample preds and labels for callbacks.
 
         Args:
             batch: Data batch.
             batch_idx: Batch index.
 
         Returns:
-            Dict with the total ``loss`` plus the raw ``preds`` and ``labels`` tuples
-            ``(energies, forces, ...)`` from this batch, suitable for consumption by a
-            Lightning ``Callback`` (e.g. ``matgl.utils.callbacks.PredictionLogger``).
+            Dict with ``loss`` (used by Lightning for backprop) plus the raw ``preds``,
+            ``labels`` tuples and per-sample ``indices`` / ``num_atoms`` so that callbacks
+            such as :class:`matgl.utils.callbacks.PredictionLogger` can place predictions in
+            a stable per-sample order across shuffled epochs.
+        """
+        loss = super().training_step(batch, batch_idx)
+        return {
+            "loss": loss,
+            "preds": self._last_preds,
+            "labels": self._last_labels,
+            "indices": self._last_indices,
+            "num_atoms": self._last_num_atoms,
+        }
+
+    def validation_step(self, batch: tuple, batch_idx: int) -> dict[str, Any]:
+        """Validation step that exposes per-sample preds and labels for callbacks.
+
+        Args:
+            batch: Data batch.
+            batch_idx: Batch index.
+
+        Returns:
+            Dict with ``loss`` plus the raw ``preds``, ``labels`` tuples and per-sample
+            ``indices`` / ``num_atoms`` (the latter only present when the dataset has been
+            stamped with :func:`matgl.utils.callbacks.add_sample_indices`).
         """
         loss = super().validation_step(batch, batch_idx)
-        return {"loss": loss, "preds": self._last_preds, "labels": self._last_labels}
+        return {
+            "loss": loss,
+            "preds": self._last_preds,
+            "labels": self._last_labels,
+            "indices": self._last_indices,
+            "num_atoms": self._last_num_atoms,
+        }
 
     def loss_fn(
         self,

--- a/src/matgl/utils/callbacks.py
+++ b/src/matgl/utils/callbacks.py
@@ -1,0 +1,127 @@
+"""Lightning callbacks for MatGL training."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import lightning as pl
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class PredictionLogger(pl.Callback):
+    """Capture per-epoch validation energy and force predictions and labels.
+
+    Plug into a ``lightning.Trainer`` via ``callbacks=[PredictionLogger(...)]`` while training
+    a :class:`matgl.utils.training.PotentialLightningModule`. After every (non-sanity-check)
+    validation epoch, this callback accumulates:
+
+    - ``energy_preds``: ``(n_epochs, n_supercells)`` total energies per supercell.
+    - ``energy_labels``: ``(n_supercells,)`` ground-truth total energies (recorded once).
+    - ``energy_errors``: ``energy_preds - energy_labels``.
+    - ``force_preds``: ``(n_epochs, n_atoms, 3)`` per-atom forces.
+    - ``force_labels``: ``(n_atoms, 3)`` ground-truth per-atom forces (recorded once).
+    - ``force_errors``: ``force_preds - force_labels``.
+
+    The validation dataloader must not shuffle so that the per-supercell axis aligns across
+    epochs (matgl's :func:`matgl.graph.MGLDataLoader` already creates ``val_loader`` with
+    ``shuffle=False``).
+
+    Args:
+        save_path: Optional path to persist the cumulative log to as a ``torch.save`` payload.
+            The file is rewritten at every validation-epoch end so it survives a crash.
+            When ``None`` the log is held in memory only and accessed via :meth:`log`.
+    """
+
+    def __init__(self, save_path: str | Path | None = None) -> None:
+        """See class docstring."""
+        super().__init__()
+        self.save_path: Path | None = Path(save_path) if save_path is not None else None
+        self._batch_e_pred: list[torch.Tensor] = []
+        self._batch_f_pred: list[torch.Tensor] = []
+        self._batch_e_label: list[torch.Tensor] = []
+        self._batch_f_label: list[torch.Tensor] = []
+        self._all_e_preds: list[torch.Tensor] = []
+        self._all_f_preds: list[torch.Tensor] = []
+        self._e_labels: torch.Tensor | None = None
+        self._f_labels: torch.Tensor | None = None
+
+    def on_validation_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Reset the per-epoch buffers."""
+        if trainer.sanity_checking:
+            return
+        self._batch_e_pred = []
+        self._batch_f_pred = []
+        self._batch_e_label = []
+        self._batch_f_label = []
+
+    def on_validation_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Mapping[str, Any] | torch.Tensor | None,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Capture this batch's preds and labels from ``validation_step``'s return dict."""
+        if trainer.sanity_checking:
+            return
+        if not isinstance(outputs, dict) or "preds" not in outputs or "labels" not in outputs:
+            raise RuntimeError(
+                "PredictionLogger requires a LightningModule whose validation_step returns "
+                "a dict with 'preds' and 'labels' keys. Use matgl PotentialLightningModule."
+            )
+        preds = outputs["preds"]
+        labels = outputs["labels"]
+        self._batch_e_pred.append(preds[0].detach().cpu().flatten())
+        self._batch_e_label.append(labels[0].detach().cpu().flatten())
+        self._batch_f_pred.append(preds[1].detach().cpu())
+        self._batch_f_label.append(labels[1].detach().cpu())
+
+    def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Stack per-batch tensors into per-epoch tensors and (optionally) persist the log."""
+        if trainer.sanity_checking:
+            return
+        if not self._batch_e_pred:
+            return
+        self._all_e_preds.append(torch.cat(self._batch_e_pred))
+        self._all_f_preds.append(torch.cat(self._batch_f_pred, dim=0))
+        if self._e_labels is None:
+            self._e_labels = torch.cat(self._batch_e_label)
+            self._f_labels = torch.cat(self._batch_f_label, dim=0)
+        if self.save_path is not None:
+            self._save(self.save_path)
+
+    @property
+    def predictions(self) -> dict[str, torch.Tensor]:
+        """Return the cumulative prediction log as a dict of tensors.
+
+        Returns:
+            Dict with keys ``energy_preds`` ``(n_epochs, n_supercells)``, ``energy_labels``
+            ``(n_supercells,)``, ``energy_errors``, ``force_preds`` ``(n_epochs, n_atoms, 3)``,
+            ``force_labels`` ``(n_atoms, 3)`` and ``force_errors``. Empty dict before the first
+            validation epoch completes.
+        """
+        if not self._all_e_preds or self._e_labels is None or self._f_labels is None:
+            return {}
+        energy_preds = torch.stack(self._all_e_preds, dim=0)
+        force_preds = torch.stack(self._all_f_preds, dim=0)
+        return {
+            "energy_preds": energy_preds,
+            "energy_labels": self._e_labels,
+            "energy_errors": energy_preds - self._e_labels.unsqueeze(0),
+            "force_preds": force_preds,
+            "force_labels": self._f_labels,
+            "force_errors": force_preds - self._f_labels.unsqueeze(0),
+        }
+
+    def _save(self, path: Path) -> None:
+        payload = self.predictions
+        if not payload:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(payload, path)

--- a/src/matgl/utils/callbacks.py
+++ b/src/matgl/utils/callbacks.py
@@ -8,55 +8,141 @@ from typing import TYPE_CHECKING, Any
 import lightning as pl
 import torch
 
+import matgl
+
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
+
+
+def add_sample_indices(dataset: Any, start: int = 0) -> None:
+    """Stamp a unique global index onto every sample's graph in ``dataset``.
+
+    The index is what :class:`PredictionLogger` uses to keep per-epoch logs sorted under a
+    shuffled training dataloader: column ``i`` of the saved energy / force arrays is always
+    the prediction for the configuration whose index is ``i``.
+
+    For PYG, the index is stored as ``data.sample_idx`` (a ``(1,)`` long tensor) on each
+    underlying ``torch_geometric.data.Data`` graph. ``Batch.from_data_list`` then collates it
+    automatically into a ``(B,)`` tensor on the batched ``Batch``.
+
+    For DGL, the index is replicated per-atom into ``g.ndata["sample_idx"]``. ``dgl.batch``
+    concatenates ``ndata`` so the per-graph index can be recovered downstream from the batch
+    boundaries given by ``g.batch_num_nodes()``.
+
+    Works with both raw ``MGLDataset`` instances and ``torch.utils.data.Subset`` /
+    ``dgl.data.utils.Subset`` returned by :func:`matgl.graph.split_dataset`. Mutation is
+    in-place: indices are written onto the shared underlying graph objects, so call this
+    after splitting and only on the subset(s) you want logged.
+
+    Args:
+        dataset: An iterable that yields ``(graph, ...)`` tuples — typically an MGLDataset
+            or a Subset thereof.
+        start: First index to assign. Defaults to 0.
+    """
+    for k, item in enumerate(dataset):
+        graph = item[0]
+        idx = start + k
+        if matgl.config.BACKEND == "PYG":
+            graph.sample_idx = torch.tensor([idx], dtype=torch.long)
+        else:
+            graph.ndata["sample_idx"] = torch.full((graph.num_nodes(),), idx, dtype=torch.long)
 
 
 class PredictionLogger(pl.Callback):
-    """Capture per-epoch validation energy and force predictions and labels.
+    """Capture per-epoch energy and force predictions, labels, and errors.
 
     Plug into a ``lightning.Trainer`` via ``callbacks=[PredictionLogger(...)]`` while training
-    a :class:`matgl.utils.training.PotentialLightningModule`. After every (non-sanity-check)
-    validation epoch, this callback accumulates:
+    a :class:`matgl.utils.training.PotentialLightningModule`. Default behaviour logs the
+    **training** set; pass ``log_validation=True`` to also (or instead) log the validation set.
 
-    - ``energy_preds``: ``(n_epochs, n_supercells)`` total energies per supercell.
-    - ``energy_labels``: ``(n_supercells,)`` ground-truth total energies (recorded once).
-    - ``energy_errors``: ``energy_preds - energy_labels``.
-    - ``force_preds``: ``(n_epochs, n_atoms, 3)`` per-atom forces.
-    - ``force_labels``: ``(n_atoms, 3)`` ground-truth per-atom forces (recorded once).
-    - ``force_errors``: ``force_preds - force_labels``.
+    The dataset(s) being logged must be stamped with global indices via
+    :func:`add_sample_indices` before training so that the ``(n_epochs, n_samples)`` log
+    columns align even though the training dataloader shuffles. Without indices the callback
+    raises at the first batch end.
 
-    The validation dataloader must not shuffle so that the per-supercell axis aligns across
-    epochs (matgl's :func:`matgl.graph.MGLDataLoader` already creates ``val_loader`` with
-    ``shuffle=False``).
+    After every (non-sanity-check) epoch the callback accumulates:
+
+    - ``{train,val}_energy_preds``: ``(n_epochs, n_samples)`` total energies per supercell.
+    - ``{train,val}_energy_labels``: ``(n_samples,)`` ground-truth total energies (recorded once).
+    - ``{train,val}_energy_errors``: ``preds - labels``.
+    - ``{train,val}_force_preds``: ``(n_epochs, n_atoms, 3)`` per-atom forces.
+    - ``{train,val}_force_labels``: ``(n_atoms, 3)`` ground-truth forces (recorded once).
+    - ``{train,val}_force_errors``: ``preds - labels``.
 
     Args:
         save_path: Optional path to persist the cumulative log to as a ``torch.save`` payload.
-            The file is rewritten at every validation-epoch end so it survives a crash.
-            When ``None`` the log is held in memory only and accessed via :meth:`log`.
+            Rewritten at every epoch end so it survives a crash. ``None`` keeps the log in
+            memory only, accessed via :attr:`predictions`.
+        log_train: Log the training set (default).
+        log_validation: Log the validation set in addition to / instead of training.
     """
 
-    def __init__(self, save_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        save_path: str | Path | None = None,
+        log_train: bool = True,
+        log_validation: bool = False,
+    ) -> None:
         """See class docstring."""
         super().__init__()
+        if not log_train and not log_validation:
+            raise ValueError("PredictionLogger requires at least one of log_train, log_validation.")
         self.save_path: Path | None = Path(save_path) if save_path is not None else None
-        self._batch_e_pred: list[torch.Tensor] = []
-        self._batch_f_pred: list[torch.Tensor] = []
-        self._batch_e_label: list[torch.Tensor] = []
-        self._batch_f_label: list[torch.Tensor] = []
-        self._all_e_preds: list[torch.Tensor] = []
-        self._all_f_preds: list[torch.Tensor] = []
-        self._e_labels: torch.Tensor | None = None
-        self._f_labels: torch.Tensor | None = None
+        self.log_train = log_train
+        self.log_validation = log_validation
+        # Per-epoch (current epoch) collected predictions, keyed by sample idx.
+        self._epoch_train: dict[int, dict[str, torch.Tensor]] = {}
+        self._epoch_val: dict[int, dict[str, torch.Tensor]] = {}
+        # Per-epoch stacked tensors accumulated over all completed epochs.
+        self._train_e_preds: list[torch.Tensor] = []
+        self._train_f_preds: list[torch.Tensor] = []
+        self._val_e_preds: list[torch.Tensor] = []
+        self._val_f_preds: list[torch.Tensor] = []
+        # Ground truth, recorded once.
+        self._train_e_labels: torch.Tensor | None = None
+        self._train_f_labels: torch.Tensor | None = None
+        self._val_e_labels: torch.Tensor | None = None
+        self._val_f_labels: torch.Tensor | None = None
+
+    # --- training hooks -------------------------------------------------------------------
+
+    def on_train_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Reset the per-epoch training buffer."""
+        if self.log_train:
+            self._epoch_train = {}
+
+    def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Mapping[str, Any] | torch.Tensor | None,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        """Capture per-sample preds for this training batch."""
+        if not self.log_train:
+            return
+        self._absorb(outputs, target=self._epoch_train)
+
+    def on_train_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Stack per-sample preds in idx order and append to running per-epoch lists."""
+        if not self.log_train or not self._epoch_train:
+            return
+        e_pred, f_pred, e_label, f_label = self._stack_epoch(self._epoch_train)
+        self._train_e_preds.append(e_pred)
+        self._train_f_preds.append(f_pred)
+        if self._train_e_labels is None:
+            self._train_e_labels = e_label
+            self._train_f_labels = f_label
+        if self.save_path is not None:
+            self._save(self.save_path)
+
+    # --- validation hooks -----------------------------------------------------------------
 
     def on_validation_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Reset the per-epoch buffers."""
-        if trainer.sanity_checking:
-            return
-        self._batch_e_pred = []
-        self._batch_f_pred = []
-        self._batch_e_label = []
-        self._batch_f_label = []
+        """Reset the per-epoch validation buffer."""
+        if self.log_validation and not trainer.sanity_checking:
+            self._epoch_val = {}
 
     def on_validation_batch_end(
         self,
@@ -67,56 +153,117 @@ class PredictionLogger(pl.Callback):
         batch_idx: int,
         dataloader_idx: int = 0,
     ) -> None:
-        """Capture this batch's preds and labels from ``validation_step``'s return dict."""
-        if trainer.sanity_checking:
+        """Capture per-sample preds for this validation batch."""
+        if not self.log_validation or trainer.sanity_checking:
             return
-        if not isinstance(outputs, dict) or "preds" not in outputs or "labels" not in outputs:
-            raise RuntimeError(
-                "PredictionLogger requires a LightningModule whose validation_step returns "
-                "a dict with 'preds' and 'labels' keys. Use matgl PotentialLightningModule."
-            )
-        preds = outputs["preds"]
-        labels = outputs["labels"]
-        self._batch_e_pred.append(preds[0].detach().cpu().flatten())
-        self._batch_e_label.append(labels[0].detach().cpu().flatten())
-        self._batch_f_pred.append(preds[1].detach().cpu())
-        self._batch_f_label.append(labels[1].detach().cpu())
+        self._absorb(outputs, target=self._epoch_val)
 
     def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Stack per-batch tensors into per-epoch tensors and (optionally) persist the log."""
-        if trainer.sanity_checking:
+        """Stack per-sample validation preds and append to running per-epoch lists."""
+        if not self.log_validation or trainer.sanity_checking or not self._epoch_val:
             return
-        if not self._batch_e_pred:
-            return
-        self._all_e_preds.append(torch.cat(self._batch_e_pred))
-        self._all_f_preds.append(torch.cat(self._batch_f_pred, dim=0))
-        if self._e_labels is None:
-            self._e_labels = torch.cat(self._batch_e_label)
-            self._f_labels = torch.cat(self._batch_f_label, dim=0)
+        e_pred, f_pred, e_label, f_label = self._stack_epoch(self._epoch_val)
+        self._val_e_preds.append(e_pred)
+        self._val_f_preds.append(f_pred)
+        if self._val_e_labels is None:
+            self._val_e_labels = e_label
+            self._val_f_labels = f_label
         if self.save_path is not None:
             self._save(self.save_path)
+
+    # --- helpers --------------------------------------------------------------------------
+
+    @staticmethod
+    def _absorb(outputs: Any, target: dict[int, dict[str, torch.Tensor]]) -> None:
+        if not isinstance(outputs, dict) or "preds" not in outputs or "labels" not in outputs:
+            raise RuntimeError(
+                "PredictionLogger requires a LightningModule whose training_step / "
+                "validation_step returns a dict with 'preds' and 'labels' keys "
+                "(matgl PotentialLightningModule does this)."
+            )
+        indices = outputs.get("indices")
+        num_atoms = outputs.get("num_atoms")
+        if indices is None or num_atoms is None:
+            raise RuntimeError(
+                "PredictionLogger could not find per-sample indices on the batch. Call "
+                "`matgl.utils.callbacks.add_sample_indices(dataset)` on the dataset (or its "
+                "subset) you are logging before constructing the dataloader."
+            )
+        e_pred = outputs["preds"][0].detach().cpu()
+        f_pred = outputs["preds"][1].detach().cpu()
+        e_label = outputs["labels"][0].detach().cpu()
+        f_label = outputs["labels"][1].detach().cpu()
+        idx_list = indices.detach().cpu().tolist()
+        n_atoms_list = num_atoms.detach().cpu().tolist()
+        offset = 0
+        for i, (idx, n) in enumerate(zip(idx_list, n_atoms_list, strict=False)):
+            target[int(idx)] = {
+                "e_pred": e_pred[i].reshape(()),
+                "f_pred": f_pred[offset : offset + n],
+                "e_label": e_label[i].reshape(()),
+                "f_label": f_label[offset : offset + n],
+            }
+            offset += n
+
+    @staticmethod
+    def _stack_epoch(
+        buf: dict[int, dict[str, torch.Tensor]],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        sorted_idx = sorted(buf.keys())
+        e_pred = torch.stack([buf[i]["e_pred"] for i in sorted_idx])
+        f_pred = torch.cat([buf[i]["f_pred"] for i in sorted_idx], dim=0)
+        e_label = torch.stack([buf[i]["e_label"] for i in sorted_idx])
+        f_label = torch.cat([buf[i]["f_label"] for i in sorted_idx], dim=0)
+        return e_pred, f_pred, e_label, f_label
 
     @property
     def predictions(self) -> dict[str, torch.Tensor]:
         """Return the cumulative prediction log as a dict of tensors.
 
-        Returns:
-            Dict with keys ``energy_preds`` ``(n_epochs, n_supercells)``, ``energy_labels``
-            ``(n_supercells,)``, ``energy_errors``, ``force_preds`` ``(n_epochs, n_atoms, 3)``,
-            ``force_labels`` ``(n_atoms, 3)`` and ``force_errors``. Empty dict before the first
-            validation epoch completes.
+        Keys are prefixed with ``train_`` and/or ``val_`` depending on which sets were logged.
+        Empty dict before the first epoch completes.
         """
-        if not self._all_e_preds or self._e_labels is None or self._f_labels is None:
+        out: dict[str, torch.Tensor] = {}
+        out.update(
+            self._collect(
+                "train",
+                self._train_e_preds,
+                self._train_f_preds,
+                self._train_e_labels,
+                self._train_f_labels,
+            )
+        )
+        out.update(
+            self._collect(
+                "val",
+                self._val_e_preds,
+                self._val_f_preds,
+                self._val_e_labels,
+                self._val_f_labels,
+            )
+        )
+        return out
+
+    @staticmethod
+    def _collect(
+        prefix: str,
+        e_preds: Iterable[torch.Tensor],
+        f_preds: Iterable[torch.Tensor],
+        e_labels: torch.Tensor | None,
+        f_labels: torch.Tensor | None,
+    ) -> dict[str, torch.Tensor]:
+        e_preds_list = list(e_preds)
+        if not e_preds_list or e_labels is None or f_labels is None:
             return {}
-        energy_preds = torch.stack(self._all_e_preds, dim=0)
-        force_preds = torch.stack(self._all_f_preds, dim=0)
+        e_stack = torch.stack(e_preds_list, dim=0)
+        f_stack = torch.stack(list(f_preds), dim=0)
         return {
-            "energy_preds": energy_preds,
-            "energy_labels": self._e_labels,
-            "energy_errors": energy_preds - self._e_labels.unsqueeze(0),
-            "force_preds": force_preds,
-            "force_labels": self._f_labels,
-            "force_errors": force_preds - self._f_labels.unsqueeze(0),
+            f"{prefix}_energy_preds": e_stack,
+            f"{prefix}_energy_labels": e_labels,
+            f"{prefix}_energy_errors": e_stack - e_labels.unsqueeze(0),
+            f"{prefix}_force_preds": f_stack,
+            f"{prefix}_force_labels": f_labels,
+            f"{prefix}_force_errors": f_stack - f_labels.unsqueeze(0),
         }
 
     def _save(self, path: Path) -> None:

--- a/tests/utils/test_training_dgl.py
+++ b/tests/utils/test_training_dgl.py
@@ -955,9 +955,9 @@ def test_xavier_init(distribution):
         assert torch.allclose(torch.tensor(0.0), model.output_proj.layers[0].get_parameter("bias"))
 
 
-def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
-    """PredictionLogger callback captures per-epoch energy/force preds (DGL backend)."""
-    from matgl.utils.callbacks import PredictionLogger
+def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger captures per-epoch train + val preds (DGL backend)."""
+    from matgl.utils.callbacks import PredictionLogger, add_sample_indices
 
     torch.manual_seed(0)
     structures = [LiFePO4, BaNiO3] * 4
@@ -980,6 +980,9 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
         shuffle=True,
         random_state=42,
     )
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+
     train_loader, val_loader = MGLDataLoader(
         train_data=train_data,
         val_data=val_data,
@@ -988,13 +991,15 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
         num_workers=0,
         generator=torch.Generator(device=device),
     )
-    n_val_supercells = len(val_data)
-    n_val_atoms = sum(val_data[i][0].num_nodes() for i in range(n_val_supercells))
+    n_train = len(train_data)
+    n_val = len(val_data)
+    n_train_atoms = sum(train_data[i][0].num_nodes() for i in range(n_train))
+    n_val_atoms = sum(val_data[i][0].num_nodes() for i in range(n_val))
 
     model = TensorNet(element_types=element_types, is_intensive=False)
     lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
     log_path = tmp_path / "predictions.pt"
-    logger_cb = PredictionLogger(save_path=log_path)
+    logger_cb = PredictionLogger(save_path=log_path, log_train=True, log_validation=True)
     n_epochs = 3
     trainer = pl.Trainer(
         max_epochs=n_epochs,
@@ -1008,15 +1013,17 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
     trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
 
     log = logger_cb.predictions
-    assert log["energy_preds"].shape == (n_epochs, n_val_supercells)
-    assert log["energy_labels"].shape == (n_val_supercells,)
-    assert log["force_preds"].shape == (n_epochs, n_val_atoms, 3)
-    assert log["force_labels"].shape == (n_val_atoms, 3)
-    assert torch.allclose(log["energy_errors"], log["energy_preds"] - log["energy_labels"].unsqueeze(0))
+    assert log["train_energy_preds"].shape == (n_epochs, n_train)
+    assert log["train_force_preds"].shape == (n_epochs, n_train_atoms, 3)
+    assert log["val_energy_preds"].shape == (n_epochs, n_val)
+    assert log["val_force_preds"].shape == (n_epochs, n_val_atoms, 3)
+    assert torch.allclose(
+        log["train_energy_errors"],
+        log["train_energy_preds"] - log["train_energy_labels"].unsqueeze(0),
+    )
 
     assert log_path.exists()
     on_disk = torch.load(log_path, weights_only=True)
-    assert torch.equal(on_disk["energy_preds"], log["energy_preds"])
-    assert torch.equal(on_disk["force_preds"], log["force_preds"])
+    assert torch.equal(on_disk["train_energy_preds"], log["train_energy_preds"])
 
     teardown()

--- a/tests/utils/test_training_dgl.py
+++ b/tests/utils/test_training_dgl.py
@@ -953,3 +953,70 @@ def test_xavier_init(distribution):
         print(w)
         assert not torch.allclose(w, model.output_proj.layers[0].get_parameter("weight"))
         assert torch.allclose(torch.tensor(0.0), model.output_proj.layers[0].get_parameter("bias"))
+
+
+def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger callback captures per-epoch energy/force preds (DGL backend)."""
+    from matgl.utils.callbacks import PredictionLogger
+
+    torch.manual_seed(0)
+    structures = [LiFePO4, BaNiO3] * 4
+    energies = [-2.0, -3.0] * 4
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        threebody_cutoff=4.0,
+        structures=structures,
+        converter=converter,
+        include_line_graph=False,
+        labels={"energies": energies, "forces": forces, "stresses": stresses},
+        save_cache=False,
+    )
+    train_data, val_data, _ = split_dataset(
+        dataset,
+        frac_list=[0.5, 0.5, 0.0],
+        shuffle=True,
+        random_state=42,
+    )
+    train_loader, val_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        collate_fn=collate_fn_pes,
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    n_val_supercells = len(val_data)
+    n_val_atoms = sum(val_data[i][0].num_nodes() for i in range(n_val_supercells))
+
+    model = TensorNet(element_types=element_types, is_intensive=False)
+    lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
+    log_path = tmp_path / "predictions.pt"
+    logger_cb = PredictionLogger(save_path=log_path)
+    n_epochs = 3
+    trainer = pl.Trainer(
+        max_epochs=n_epochs,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_cb],
+    )
+    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+    log = logger_cb.predictions
+    assert log["energy_preds"].shape == (n_epochs, n_val_supercells)
+    assert log["energy_labels"].shape == (n_val_supercells,)
+    assert log["force_preds"].shape == (n_epochs, n_val_atoms, 3)
+    assert log["force_labels"].shape == (n_val_atoms, 3)
+    assert torch.allclose(log["energy_errors"], log["energy_preds"] - log["energy_labels"].unsqueeze(0))
+
+    assert log_path.exists()
+    on_disk = torch.load(log_path, weights_only=True)
+    assert torch.equal(on_disk["energy_preds"], log["energy_preds"])
+    assert torch.equal(on_disk["force_preds"], log["force_preds"])
+
+    teardown()

--- a/tests/utils/test_training_pyg.py
+++ b/tests/utils/test_training_pyg.py
@@ -172,6 +172,128 @@ class TestModelTrainer:
             pass
 
 
+def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger callback captures per-epoch energy/force preds and persists them."""
+    from matgl.utils.callbacks import PredictionLogger
+
+    torch.manual_seed(0)
+    structures = [LiFePO4, BaNiO3] * 4
+    energies = [-2.0, -3.0] * 4
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        structures=structures,
+        converter=converter,
+        labels={"energies": energies, "forces": forces, "stresses": stresses},
+        save_cache=False,
+    )
+    train_data, val_data, _test_data = split_dataset(
+        dataset,
+        frac_list=[0.5, 0.5, 0.0],
+        shuffle=True,
+        random_state=42,
+    )
+    train_loader, val_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        collate_fn=collate_fn_pes,
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    n_val_supercells = len(val_data)
+    n_val_atoms = sum(val_data[i][0].num_nodes for i in range(n_val_supercells))
+
+    model = TensorNet(element_types=element_types, is_intensive=False, use_warp=False)
+    lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
+    log_path = tmp_path / "predictions.pt"
+    logger_cb = PredictionLogger(save_path=log_path)
+    n_epochs = 3
+    trainer = pl.Trainer(
+        max_epochs=n_epochs,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_cb],
+    )
+    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+    log = logger_cb.predictions
+    assert log["energy_preds"].shape == (n_epochs, n_val_supercells)
+    assert log["energy_labels"].shape == (n_val_supercells,)
+    assert log["energy_errors"].shape == (n_epochs, n_val_supercells)
+    assert log["force_preds"].shape == (n_epochs, n_val_atoms, 3)
+    assert log["force_labels"].shape == (n_val_atoms, 3)
+    assert log["force_errors"].shape == (n_epochs, n_val_atoms, 3)
+    assert torch.allclose(
+        log["energy_errors"],
+        log["energy_preds"] - log["energy_labels"].unsqueeze(0),
+    )
+    # Ground-truth forces in the val loader were all zero.
+    assert torch.allclose(log["force_labels"], torch.zeros(n_val_atoms, 3))
+
+    assert log_path.exists()
+    on_disk = torch.load(log_path, weights_only=True)
+    assert torch.equal(on_disk["energy_preds"], log["energy_preds"])
+    assert torch.equal(on_disk["force_preds"], log["force_preds"])
+
+    try:
+        shutil.rmtree("lightning_logs")
+    except FileNotFoundError:
+        pass
+
+
+def test_prediction_logger_in_memory_only(LiFePO4, BaNiO3):
+    """Without ``save_path``, PredictionLogger keeps the cumulative log in memory."""
+    from matgl.utils.callbacks import PredictionLogger
+
+    torch.manual_seed(0)
+    structures = [LiFePO4, BaNiO3] * 4
+    energies = [-2.0, -3.0] * 4
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        structures=structures,
+        converter=converter,
+        labels={"energies": energies, "forces": forces, "stresses": stresses},
+        save_cache=False,
+    )
+    train_data, val_data, _ = split_dataset(dataset, frac_list=[0.5, 0.5, 0.0], shuffle=True, random_state=42)
+    train_loader, val_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        collate_fn=collate_fn_pes,
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    model = TensorNet(element_types=element_types, is_intensive=False, use_warp=False)
+    lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
+    logger_cb = PredictionLogger()
+    trainer = pl.Trainer(
+        max_epochs=2,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_cb],
+    )
+    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+    assert logger_cb.predictions["energy_preds"].shape[0] == 2
+
+    try:
+        shutil.rmtree("lightning_logs")
+    except FileNotFoundError:
+        pass
+
+
 def _make_efs_batch():
     """Tiny synthetic (preds, labels) tuple usable by PotentialLightningModule.loss_fn.
 

--- a/tests/utils/test_training_pyg.py
+++ b/tests/utils/test_training_pyg.py
@@ -172,9 +172,9 @@ class TestModelTrainer:
             pass
 
 
-def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
-    """PredictionLogger callback captures per-epoch energy/force preds and persists them."""
-    from matgl.utils.callbacks import PredictionLogger
+def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger captures per-epoch train + val preds in a stable per-sample order."""
+    from matgl.utils.callbacks import PredictionLogger, add_sample_indices
 
     torch.manual_seed(0)
     structures = [LiFePO4, BaNiO3] * 4
@@ -195,6 +195,9 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
         shuffle=True,
         random_state=42,
     )
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+
     train_loader, val_loader = MGLDataLoader(
         train_data=train_data,
         val_data=val_data,
@@ -203,13 +206,15 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
         num_workers=0,
         generator=torch.Generator(device=device),
     )
-    n_val_supercells = len(val_data)
-    n_val_atoms = sum(val_data[i][0].num_nodes for i in range(n_val_supercells))
+    n_train = len(train_data)
+    n_val = len(val_data)
+    n_train_atoms = sum(train_data[i][0].num_nodes for i in range(n_train))
+    n_val_atoms = sum(val_data[i][0].num_nodes for i in range(n_val))
 
     model = TensorNet(element_types=element_types, is_intensive=False, use_warp=False)
     lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
     log_path = tmp_path / "predictions.pt"
-    logger_cb = PredictionLogger(save_path=log_path)
+    logger_cb = PredictionLogger(save_path=log_path, log_train=True, log_validation=True)
     n_epochs = 3
     trainer = pl.Trainer(
         max_epochs=n_epochs,
@@ -223,23 +228,24 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
     trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
 
     log = logger_cb.predictions
-    assert log["energy_preds"].shape == (n_epochs, n_val_supercells)
-    assert log["energy_labels"].shape == (n_val_supercells,)
-    assert log["energy_errors"].shape == (n_epochs, n_val_supercells)
-    assert log["force_preds"].shape == (n_epochs, n_val_atoms, 3)
-    assert log["force_labels"].shape == (n_val_atoms, 3)
-    assert log["force_errors"].shape == (n_epochs, n_val_atoms, 3)
+    assert log["train_energy_preds"].shape == (n_epochs, n_train)
+    assert log["train_energy_labels"].shape == (n_train,)
+    assert log["train_force_preds"].shape == (n_epochs, n_train_atoms, 3)
+    assert log["train_force_labels"].shape == (n_train_atoms, 3)
+    assert log["val_energy_preds"].shape == (n_epochs, n_val)
+    assert log["val_force_preds"].shape == (n_epochs, n_val_atoms, 3)
+    # Errors are preds - labels.
     assert torch.allclose(
-        log["energy_errors"],
-        log["energy_preds"] - log["energy_labels"].unsqueeze(0),
+        log["train_energy_errors"],
+        log["train_energy_preds"] - log["train_energy_labels"].unsqueeze(0),
     )
-    # Ground-truth forces in the val loader were all zero.
-    assert torch.allclose(log["force_labels"], torch.zeros(n_val_atoms, 3))
+    # Ground-truth forces in the loaders were all zero.
+    assert torch.allclose(log["train_force_labels"], torch.zeros(n_train_atoms, 3))
 
     assert log_path.exists()
     on_disk = torch.load(log_path, weights_only=True)
-    assert torch.equal(on_disk["energy_preds"], log["energy_preds"])
-    assert torch.equal(on_disk["force_preds"], log["force_preds"])
+    assert torch.equal(on_disk["train_energy_preds"], log["train_energy_preds"])
+    assert torch.equal(on_disk["val_energy_preds"], log["val_energy_preds"])
 
     try:
         shutil.rmtree("lightning_logs")
@@ -247,13 +253,13 @@ def test_prediction_logger_callback(LiFePO4, BaNiO3, tmp_path):
         pass
 
 
-def test_prediction_logger_in_memory_only(LiFePO4, BaNiO3):
-    """Without ``save_path``, PredictionLogger keeps the cumulative log in memory."""
+def test_prediction_logger_requires_indices(LiFePO4, BaNiO3):
+    """PredictionLogger raises a clear error when add_sample_indices wasn't called."""
     from matgl.utils.callbacks import PredictionLogger
 
     torch.manual_seed(0)
-    structures = [LiFePO4, BaNiO3] * 4
-    energies = [-2.0, -3.0] * 4
+    structures = [LiFePO4, BaNiO3] * 2
+    energies = [-2.0, -3.0] * 2
     forces = [np.zeros((len(s), 3)).tolist() for s in structures]
     stresses = [np.zeros((3, 3)).tolist()] * len(structures)
     element_types = get_element_list([LiFePO4, BaNiO3])
@@ -277,7 +283,7 @@ def test_prediction_logger_in_memory_only(LiFePO4, BaNiO3):
     lit_model = PotentialLightningModule(model=model, stress_weight=0.0, loss="mse_loss")
     logger_cb = PredictionLogger()
     trainer = pl.Trainer(
-        max_epochs=2,
+        max_epochs=1,
         accelerator=device,
         inference_mode=False,
         num_sanity_val_steps=0,
@@ -285,8 +291,8 @@ def test_prediction_logger_in_memory_only(LiFePO4, BaNiO3):
         logger=False,
         callbacks=[logger_cb],
     )
-    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
-    assert logger_cb.predictions["energy_preds"].shape[0] == 2
+    with pytest.raises(RuntimeError, match="add_sample_indices"):
+        trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
 
     try:
         shutil.rmtree("lightning_logs")


### PR DESCRIPTION
## Summary

- New `matgl.utils.callbacks.PredictionLogger` Lightning callback that captures per-epoch **energy** and **per-atom force** predictions, ground truth, and errors. Defaults to logging the **training** set; pass `log_validation=True` to also log the validation set.
- New `matgl.utils.callbacks.add_sample_indices(dataset)` helper that stamps a unique global index onto every sample's graph (`Data.sample_idx` for PyG; `g.ndata['sample_idx']` for DGL). The callback uses these indices to keep the `(n_epochs, n_samples)` log columns in a stable order across the training dataloader's shuffles — column `i` is always the same configuration in every epoch.
- `PotentialLightningModule.training_step` and `validation_step` (PYG and DGL) now return a dict with `loss`, `preds`, `labels`, `indices`, `num_atoms`, so the callback can consume per-sample data without re-running the model.
- Tests cover both backends (train+val ordering, and a clear error when `add_sample_indices` was forgotten). Pre-commit hooks (ruff, mypy, codespell) all green.

## Usage

```python
from lightning import Trainer
from matgl.graph._data_pyg import MGLDataLoader, collate_fn_pes, split_dataset
from matgl.utils.callbacks import PredictionLogger, add_sample_indices
from matgl.utils.training import PotentialLightningModule

train_data, val_data, test_data = split_dataset(dataset, frac_list=[0.8, 0.1, 0.1])
add_sample_indices(train_data)         # stamp 0..N_train-1 onto each train graph
add_sample_indices(val_data)            # only needed if log_validation=True

train_loader, val_loader, _ = MGLDataLoader(
    train_data=train_data, val_data=val_data, test_data=test_data,
    collate_fn=collate_fn_pes, batch_size=32,
)

logger = PredictionLogger(save_path="run/predictions.pt", log_train=True, log_validation=True)
lit = PotentialLightningModule(model=model, stress_weight=1e-4)
trainer = Trainer(max_epochs=100, callbacks=[logger])
trainer.fit(lit, train_dataloaders=train_loader, val_dataloaders=val_loader)

log = logger.predictions
log["train_energy_preds"]   # (n_epochs, n_train_samples)
log["train_force_preds"]    # (n_epochs, n_train_atoms, 3)
log["train_energy_errors"]; log["train_force_errors"]
log["train_energy_labels"]; log["train_force_labels"]
log["val_energy_preds"]     # (n_epochs, n_val_samples) — present when log_validation=True
```

`save_path` is rewritten at every epoch end, so the cumulative log survives a crash. Sanity-check epochs are skipped automatically. Energies and forces are always logged together — there's no separate force toggle.

## Test plan

- [x] `uv run pytest tests/utils/test_training_pyg.py` (19 passed, including `test_prediction_logger_train_and_val` and `test_prediction_logger_requires_indices`)
- [x] `MATGL_BACKEND=DGL .venv_dgl/bin/python -m pytest tests/utils/test_training_dgl.py::test_prediction_logger_train_and_val tests/utils/test_training_dgl.py::test_tensornet_training` (passed)
- [x] `uv run ruff check src` + `uv run --with mypy mypy -p matgl` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)