### PR TITLE
feat: log stress and charge predictions in PredictionLogger

### DIFF
--- a/src/matgl/utils/callbacks.py
+++ b/src/matgl/utils/callbacks.py
@@ -11,7 +11,7 @@ import torch
 import matgl
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Mapping
 
 
 def add_sample_indices(dataset: Any, start: int = 0) -> None:
@@ -49,11 +49,16 @@ def add_sample_indices(dataset: Any, start: int = 0) -> None:
 
 
 class PredictionLogger(pl.Callback):
-    """Capture per-epoch energy and force predictions, labels, and errors.
+    """Capture per-epoch predictions, labels, and errors during training.
 
     Plug into a ``lightning.Trainer`` via ``callbacks=[PredictionLogger(...)]`` while training
     a :class:`matgl.utils.training.PotentialLightningModule`. Default behaviour logs the
     **training** set; pass ``log_validation=True`` to also (or instead) log the validation set.
+
+    Energies and forces are always logged. Stresses and per-atom charges are logged
+    automatically when the wrapped potential computes them (i.e. when
+    ``model.calc_stresses`` / ``model.calc_charge`` is true) — pass ``log_stress=False`` or
+    ``log_charge=False`` to opt out.
 
     The dataset(s) being logged must be stamped with global indices via
     :func:`add_sample_indices` before training so that the ``(n_epochs, n_samples)`` log
@@ -63,11 +68,15 @@ class PredictionLogger(pl.Callback):
     After every (non-sanity-check) epoch the callback accumulates:
 
     - ``{train,val}_energy_preds``: ``(n_epochs, n_samples)`` total energies per supercell.
-    - ``{train,val}_energy_labels``: ``(n_samples,)`` ground-truth total energies (recorded once).
+    - ``{train,val}_energy_labels``: ``(n_samples,)`` ground-truth total energies.
     - ``{train,val}_energy_errors``: ``preds - labels``.
     - ``{train,val}_force_preds``: ``(n_epochs, n_atoms, 3)`` per-atom forces.
-    - ``{train,val}_force_labels``: ``(n_atoms, 3)`` ground-truth forces (recorded once).
+    - ``{train,val}_force_labels``: ``(n_atoms, 3)`` ground-truth forces.
     - ``{train,val}_force_errors``: ``preds - labels``.
+    - ``{train,val}_stress_preds`` (if logged): ``(n_epochs, n_samples, 3, 3)`` per-supercell stresses.
+    - ``{train,val}_stress_labels`` / ``..._errors`` analogously.
+    - ``{train,val}_charge_preds`` (if logged): ``(n_epochs, n_atoms)`` per-atom charges.
+    - ``{train,val}_charge_labels`` / ``..._errors`` analogously.
 
     Args:
         save_path: Optional path to persist the cumulative log to as a ``torch.save`` payload.
@@ -75,13 +84,19 @@ class PredictionLogger(pl.Callback):
             memory only, accessed via :attr:`predictions`.
         log_train: Log the training set (default).
         log_validation: Log the validation set in addition to / instead of training.
+        log_stress: Log stresses when ``model.calc_stresses`` is true (default).
+        log_charge: Log per-atom charges when ``model.calc_charge`` is true (default).
     """
+
+    _METRICS = ("e", "f", "s", "q")
 
     def __init__(
         self,
         save_path: str | Path | None = None,
         log_train: bool = True,
         log_validation: bool = False,
+        log_stress: bool = True,
+        log_charge: bool = True,
     ) -> None:
         """See class docstring."""
         super().__init__()
@@ -90,19 +105,17 @@ class PredictionLogger(pl.Callback):
         self.save_path: Path | None = Path(save_path) if save_path is not None else None
         self.log_train = log_train
         self.log_validation = log_validation
+        self.log_stress = log_stress
+        self.log_charge = log_charge
         # Per-epoch (current epoch) collected predictions, keyed by sample idx.
         self._epoch_train: dict[int, dict[str, torch.Tensor]] = {}
         self._epoch_val: dict[int, dict[str, torch.Tensor]] = {}
         # Per-epoch stacked tensors accumulated over all completed epochs.
-        self._train_e_preds: list[torch.Tensor] = []
-        self._train_f_preds: list[torch.Tensor] = []
-        self._val_e_preds: list[torch.Tensor] = []
-        self._val_f_preds: list[torch.Tensor] = []
+        self._train_preds: dict[str, list[torch.Tensor]] = {m: [] for m in self._METRICS}
+        self._val_preds: dict[str, list[torch.Tensor]] = {m: [] for m in self._METRICS}
         # Ground truth, recorded once.
-        self._train_e_labels: torch.Tensor | None = None
-        self._train_f_labels: torch.Tensor | None = None
-        self._val_e_labels: torch.Tensor | None = None
-        self._val_f_labels: torch.Tensor | None = None
+        self._train_labels: dict[str, torch.Tensor | None] = dict.fromkeys(self._METRICS)
+        self._val_labels: dict[str, torch.Tensor | None] = dict.fromkeys(self._METRICS)
 
     # --- training hooks -------------------------------------------------------------------
 
@@ -122,18 +135,13 @@ class PredictionLogger(pl.Callback):
         """Capture per-sample preds for this training batch."""
         if not self.log_train:
             return
-        self._absorb(outputs, target=self._epoch_train)
+        self._absorb(outputs, target=self._epoch_train, pl_module=pl_module)
 
     def on_train_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Stack per-sample preds in idx order and append to running per-epoch lists."""
         if not self.log_train or not self._epoch_train:
             return
-        e_pred, f_pred, e_label, f_label = self._stack_epoch(self._epoch_train)
-        self._train_e_preds.append(e_pred)
-        self._train_f_preds.append(f_pred)
-        if self._train_e_labels is None:
-            self._train_e_labels = e_label
-            self._train_f_labels = f_label
+        self._absorb_epoch(self._epoch_train, self._train_preds, self._train_labels)
         if self.save_path is not None:
             self._save(self.save_path)
 
@@ -156,25 +164,24 @@ class PredictionLogger(pl.Callback):
         """Capture per-sample preds for this validation batch."""
         if not self.log_validation or trainer.sanity_checking:
             return
-        self._absorb(outputs, target=self._epoch_val)
+        self._absorb(outputs, target=self._epoch_val, pl_module=pl_module)
 
     def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Stack per-sample validation preds and append to running per-epoch lists."""
         if not self.log_validation or trainer.sanity_checking or not self._epoch_val:
             return
-        e_pred, f_pred, e_label, f_label = self._stack_epoch(self._epoch_val)
-        self._val_e_preds.append(e_pred)
-        self._val_f_preds.append(f_pred)
-        if self._val_e_labels is None:
-            self._val_e_labels = e_label
-            self._val_f_labels = f_label
+        self._absorb_epoch(self._epoch_val, self._val_preds, self._val_labels)
         if self.save_path is not None:
             self._save(self.save_path)
 
     # --- helpers --------------------------------------------------------------------------
 
-    @staticmethod
-    def _absorb(outputs: Any, target: dict[int, dict[str, torch.Tensor]]) -> None:
+    def _absorb(
+        self,
+        outputs: Any,
+        target: dict[int, dict[str, torch.Tensor]],
+        pl_module: pl.LightningModule,
+    ) -> None:
         if not isinstance(outputs, dict) or "preds" not in outputs or "labels" not in outputs:
             raise RuntimeError(
                 "PredictionLogger requires a LightningModule whose training_step / "
@@ -189,32 +196,77 @@ class PredictionLogger(pl.Callback):
                 "`matgl.utils.callbacks.add_sample_indices(dataset)` on the dataset (or its "
                 "subset) you are logging before constructing the dataloader."
             )
-        e_pred = outputs["preds"][0].detach().cpu()
-        f_pred = outputs["preds"][1].detach().cpu()
-        e_label = outputs["labels"][0].detach().cpu()
-        f_label = outputs["labels"][1].detach().cpu()
+        preds = outputs["preds"]
+        labels = outputs["labels"]
+        model = getattr(pl_module, "model", None)
+        log_stress = self.log_stress and getattr(model, "calc_stresses", False)
+        log_charge = self.log_charge and getattr(model, "calc_charge", False) and len(preds) >= 4
+
+        e_pred = preds[0].detach().cpu()
+        f_pred = preds[1].detach().cpu()
+        e_label = labels[0].detach().cpu()
+        f_label = labels[1].detach().cpu()
+        # Stresses come back from collate_fn_pes / Potential as a flat (B*3, 3) stack —
+        # reshape into (B, 3, 3) so we can index per-sample.
+        if log_stress:
+            s_pred = preds[2].detach().cpu().reshape(-1, 3, 3)
+            s_label = labels[2].detach().cpu().reshape(-1, 3, 3)
+        if log_charge:
+            q_pred = preds[3].detach().cpu()
+            q_label = labels[3].detach().cpu()
+
         idx_list = indices.detach().cpu().tolist()
         n_atoms_list = num_atoms.detach().cpu().tolist()
         offset = 0
         for i, (idx, n) in enumerate(zip(idx_list, n_atoms_list, strict=False)):
-            target[int(idx)] = {
+            entry: dict[str, torch.Tensor] = {
                 "e_pred": e_pred[i].reshape(()),
                 "f_pred": f_pred[offset : offset + n],
                 "e_label": e_label[i].reshape(()),
                 "f_label": f_label[offset : offset + n],
             }
+            if log_stress:
+                entry["s_pred"] = s_pred[i]
+                entry["s_label"] = s_label[i]
+            if log_charge:
+                entry["q_pred"] = q_pred[offset : offset + n]
+                entry["q_label"] = q_label[offset : offset + n]
+            target[int(idx)] = entry
             offset += n
 
     @staticmethod
-    def _stack_epoch(
-        buf: dict[int, dict[str, torch.Tensor]],
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _stack_epoch(buf: dict[int, dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
         sorted_idx = sorted(buf.keys())
-        e_pred = torch.stack([buf[i]["e_pred"] for i in sorted_idx])
-        f_pred = torch.cat([buf[i]["f_pred"] for i in sorted_idx], dim=0)
-        e_label = torch.stack([buf[i]["e_label"] for i in sorted_idx])
-        f_label = torch.cat([buf[i]["f_label"] for i in sorted_idx], dim=0)
-        return e_pred, f_pred, e_label, f_label
+        sample = buf[sorted_idx[0]]
+        out: dict[str, torch.Tensor] = {
+            "e_pred": torch.stack([buf[i]["e_pred"] for i in sorted_idx]),
+            "f_pred": torch.cat([buf[i]["f_pred"] for i in sorted_idx], dim=0),
+            "e_label": torch.stack([buf[i]["e_label"] for i in sorted_idx]),
+            "f_label": torch.cat([buf[i]["f_label"] for i in sorted_idx], dim=0),
+        }
+        if "s_pred" in sample:
+            out["s_pred"] = torch.stack([buf[i]["s_pred"] for i in sorted_idx])
+            out["s_label"] = torch.stack([buf[i]["s_label"] for i in sorted_idx])
+        if "q_pred" in sample:
+            out["q_pred"] = torch.cat([buf[i]["q_pred"] for i in sorted_idx], dim=0)
+            out["q_label"] = torch.cat([buf[i]["q_label"] for i in sorted_idx], dim=0)
+        return out
+
+    def _absorb_epoch(
+        self,
+        epoch_buf: dict[int, dict[str, torch.Tensor]],
+        preds_store: dict[str, list[torch.Tensor]],
+        labels_store: dict[str, torch.Tensor | None],
+    ) -> None:
+        stacked = self._stack_epoch(epoch_buf)
+        for m in self._METRICS:
+            pred_key = f"{m}_pred"
+            label_key = f"{m}_label"
+            if pred_key not in stacked:
+                continue
+            preds_store[m].append(stacked[pred_key])
+            if labels_store[m] is None:
+                labels_store[m] = stacked[label_key]
 
     @property
     def predictions(self) -> dict[str, torch.Tensor]:
@@ -224,47 +276,30 @@ class PredictionLogger(pl.Callback):
         Empty dict before the first epoch completes.
         """
         out: dict[str, torch.Tensor] = {}
-        out.update(
-            self._collect(
-                "train",
-                self._train_e_preds,
-                self._train_f_preds,
-                self._train_e_labels,
-                self._train_f_labels,
-            )
-        )
-        out.update(
-            self._collect(
-                "val",
-                self._val_e_preds,
-                self._val_f_preds,
-                self._val_e_labels,
-                self._val_f_labels,
-            )
-        )
+        out.update(self._collect("train", self._train_preds, self._train_labels))
+        out.update(self._collect("val", self._val_preds, self._val_labels))
         return out
 
     @staticmethod
     def _collect(
         prefix: str,
-        e_preds: Iterable[torch.Tensor],
-        f_preds: Iterable[torch.Tensor],
-        e_labels: torch.Tensor | None,
-        f_labels: torch.Tensor | None,
+        preds_store: dict[str, list[torch.Tensor]],
+        labels_store: dict[str, torch.Tensor | None],
     ) -> dict[str, torch.Tensor]:
-        e_preds_list = list(e_preds)
-        if not e_preds_list or e_labels is None or f_labels is None:
+        if not preds_store["e"] or labels_store["e"] is None:
             return {}
-        e_stack = torch.stack(e_preds_list, dim=0)
-        f_stack = torch.stack(list(f_preds), dim=0)
-        return {
-            f"{prefix}_energy_preds": e_stack,
-            f"{prefix}_energy_labels": e_labels,
-            f"{prefix}_energy_errors": e_stack - e_labels.unsqueeze(0),
-            f"{prefix}_force_preds": f_stack,
-            f"{prefix}_force_labels": f_labels,
-            f"{prefix}_force_errors": f_stack - f_labels.unsqueeze(0),
-        }
+        names = {"e": "energy", "f": "force", "s": "stress", "q": "charge"}
+        out: dict[str, torch.Tensor] = {}
+        for short, long in names.items():
+            preds_list = preds_store[short]
+            label = labels_store[short]
+            if not preds_list or label is None:
+                continue
+            stacked = torch.stack(preds_list, dim=0)
+            out[f"{prefix}_{long}_preds"] = stacked
+            out[f"{prefix}_{long}_labels"] = label
+            out[f"{prefix}_{long}_errors"] = stacked - label.unsqueeze(0)
+        return out
 
     def _save(self, path: Path) -> None:
         payload = self.predictions

--- a/tests/utils/test_training_dgl.py
+++ b/tests/utils/test_training_dgl.py
@@ -1027,3 +1027,85 @@ def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
     assert torch.equal(on_disk["train_energy_preds"], log["train_energy_preds"])
 
     teardown()
+
+
+def test_prediction_logger_with_stress_and_charge(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger captures per-epoch stress and per-atom charge predictions (DGL)."""
+    from matgl.utils.callbacks import PredictionLogger, add_sample_indices
+
+    torch.manual_seed(0)
+    structures = [LiFePO4, BaNiO3] * 4
+    energies = [-2.0, -3.0] * 4
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    charges = [np.zeros(len(s)).tolist() for s in structures]
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        threebody_cutoff=4.0,
+        structures=structures,
+        converter=converter,
+        include_line_graph=False,
+        include_ref_charge=True,
+        labels={"energies": energies, "forces": forces, "stresses": stresses, "charges": charges},
+        save_cache=False,
+    )
+    train_data, val_data, _ = split_dataset(
+        dataset,
+        frac_list=[0.5, 0.5, 0.0],
+        shuffle=True,
+        random_state=42,
+    )
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+    train_loader, val_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        collate_fn=partial(collate_fn_pes, include_charge=True),
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    n_train = len(train_data)
+    n_val = len(val_data)
+    n_train_atoms = sum(train_data[i][0].num_nodes() for i in range(n_train))
+    n_val_atoms = sum(val_data[i][0].num_nodes() for i in range(n_val))
+
+    model = QET(element_types=element_types, is_intensive=False, use_smooth=True, rbf_type="SphericalBessel")
+    lit_model = PotentialLightningModule(
+        model=model,
+        stress_weight=0.0001,
+        charge_weight=0.001,
+        loss="mse_loss",
+    )
+    log_path = tmp_path / "predictions.pt"
+    logger_cb = PredictionLogger(save_path=log_path, log_train=True, log_validation=True)
+    n_epochs = 2
+    trainer = pl.Trainer(
+        max_epochs=n_epochs,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_cb],
+    )
+    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+    log = logger_cb.predictions
+    assert log["train_stress_preds"].shape == (n_epochs, n_train, 3, 3)
+    assert log["train_stress_labels"].shape == (n_train, 3, 3)
+    assert torch.allclose(
+        log["train_stress_errors"],
+        log["train_stress_preds"] - log["train_stress_labels"].unsqueeze(0),
+    )
+    assert log["train_charge_preds"].shape == (n_epochs, n_train_atoms)
+    assert log["train_charge_labels"].shape == (n_train_atoms,)
+    assert log["val_stress_preds"].shape == (n_epochs, n_val, 3, 3)
+    assert log["val_charge_preds"].shape == (n_epochs, n_val_atoms)
+
+    on_disk = torch.load(log_path, weights_only=True)
+    assert torch.equal(on_disk["train_stress_preds"], log["train_stress_preds"])
+    assert torch.equal(on_disk["train_charge_preds"], log["train_charge_preds"])
+
+    teardown()

--- a/tests/utils/test_training_pyg.py
+++ b/tests/utils/test_training_pyg.py
@@ -253,6 +253,114 @@ def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
         pass
 
 
+def test_prediction_logger_with_stress_and_charge(LiFePO4, BaNiO3, tmp_path):
+    """PredictionLogger captures per-epoch stress and per-atom charge predictions."""
+    from matgl.utils.callbacks import PredictionLogger, add_sample_indices
+
+    torch.manual_seed(0)
+    structures = [LiFePO4, BaNiO3] * 4
+    energies = [-2.0, -3.0] * 4
+    forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+    stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+    charges = [np.zeros(len(s)).tolist() for s in structures]
+    element_types = get_element_list([LiFePO4, BaNiO3])
+    converter = Structure2Graph(element_types=element_types, cutoff=5.0)
+    dataset = MGLDataset(
+        structures=structures,
+        converter=converter,
+        include_ref_charge=True,
+        labels={"energies": energies, "forces": forces, "stresses": stresses, "charges": charges},
+        save_cache=False,
+    )
+    train_data, val_data, _test_data = split_dataset(
+        dataset,
+        frac_list=[0.5, 0.5, 0.0],
+        shuffle=True,
+        random_state=42,
+    )
+    add_sample_indices(train_data)
+    add_sample_indices(val_data)
+
+    train_loader, val_loader = MGLDataLoader(
+        train_data=train_data,
+        val_data=val_data,
+        collate_fn=partial(collate_fn_pes, include_charge=True),
+        batch_size=2,
+        num_workers=0,
+        generator=torch.Generator(device=device),
+    )
+    n_train = len(train_data)
+    n_val = len(val_data)
+    n_train_atoms = sum(train_data[i][0].num_nodes for i in range(n_train))
+    n_val_atoms = sum(val_data[i][0].num_nodes for i in range(n_val))
+
+    model = QET(element_types=element_types, is_intensive=False, use_smooth=True, rbf_type="SphericalBessel")
+    lit_model = PotentialLightningModule(
+        model=model,
+        stress_weight=0.0001,
+        charge_weight=0.001,
+        loss="mse_loss",
+    )
+    log_path = tmp_path / "predictions.pt"
+    logger_cb = PredictionLogger(save_path=log_path, log_train=True, log_validation=True)
+    n_epochs = 2
+    trainer = pl.Trainer(
+        max_epochs=n_epochs,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_cb],
+    )
+    trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+    log = logger_cb.predictions
+    # Energy / force still logged.
+    assert log["train_energy_preds"].shape == (n_epochs, n_train)
+    assert log["train_force_preds"].shape == (n_epochs, n_train_atoms, 3)
+    # Stress: per-supercell 3x3.
+    assert log["train_stress_preds"].shape == (n_epochs, n_train, 3, 3)
+    assert log["train_stress_labels"].shape == (n_train, 3, 3)
+    assert torch.allclose(log["train_stress_labels"], torch.zeros(n_train, 3, 3))
+    assert torch.allclose(
+        log["train_stress_errors"],
+        log["train_stress_preds"] - log["train_stress_labels"].unsqueeze(0),
+    )
+    # Per-atom charges.
+    assert log["train_charge_preds"].shape == (n_epochs, n_train_atoms)
+    assert log["train_charge_labels"].shape == (n_train_atoms,)
+    assert torch.allclose(log["train_charge_labels"], torch.zeros(n_train_atoms))
+    # Validation set carries the same shapes.
+    assert log["val_stress_preds"].shape == (n_epochs, n_val, 3, 3)
+    assert log["val_charge_preds"].shape == (n_epochs, n_val_atoms)
+
+    on_disk = torch.load(log_path, weights_only=True)
+    assert torch.equal(on_disk["train_stress_preds"], log["train_stress_preds"])
+    assert torch.equal(on_disk["train_charge_preds"], log["train_charge_preds"])
+
+    # Opt-out path: log_stress=False, log_charge=False keeps only energy + forces.
+    logger_off = PredictionLogger(log_train=True, log_validation=False, log_stress=False, log_charge=False)
+    trainer_off = pl.Trainer(
+        max_epochs=1,
+        accelerator=device,
+        inference_mode=False,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        logger=False,
+        callbacks=[logger_off],
+    )
+    trainer_off.fit(model=lit_model, train_dataloaders=train_loader)
+    log_off = logger_off.predictions
+    assert "train_stress_preds" not in log_off
+    assert "train_charge_preds" not in log_off
+
+    try:
+        shutil.rmtree("lightning_logs")
+    except FileNotFoundError:
+        pass
+
+
 def test_prediction_logger_requires_indices(LiFePO4, BaNiO3):
     """PredictionLogger raises a clear error when add_sample_indices wasn't called."""
     from matgl.utils.callbacks import PredictionLogger


### PR DESCRIPTION
## Summary

Extend the ``PredictionLogger`` callback (introduced in #775) to also capture per-epoch **stress** and **per-atom charge** predictions alongside energy and forces. Auto-detected: both fire whenever the wrapped ``Potential`` computes them (``model.calc_stresses`` / ``model.calc_charge``); pass ``log_stress=False`` or ``log_charge=False`` to opt out.

New keys in the saved payload (per logged set, prefix ``train_`` and/or ``val_``):

- ``stress_preds`` — ``(n_epochs, n_samples, 3, 3)`` per-supercell stress
- ``stress_labels`` — ``(n_samples, 3, 3)``
- ``stress_errors`` — ``preds - labels``
- ``charge_preds`` — ``(n_epochs, n_atoms)`` per-atom charge
- ``charge_labels`` — ``(n_atoms,)``
- ``charge_errors`` — ``preds - labels``

Internally the per-metric buffers are now a single dict keyed by ``{e, f, s, q}`` so adding metrics later (e.g. magmom) is mechanical. Energy / force behaviour is unchanged.

## Test plan

- [x] `uv run pytest tests/utils/test_training_pyg.py` — 20 passed (incl. new ``test_prediction_logger_with_stress_and_charge``)
- [x] `MATGL_BACKEND=DGL .venv_dgl/bin/python -m pytest tests/utils/test_training_dgl.py` — 19 passed (incl. matching new test)
- [x] `uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run --with mypy mypy -p matgl` — all clean
- [x] PYG test additionally verifies the opt-out path: ``log_stress=False, log_charge=False`` drops the new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)