### PR TITLE
feat(training): add fit_element_refs helper

### DIFF
--- a/src/matgl/utils/training.py
+++ b/src/matgl/utils/training.py
@@ -13,6 +13,7 @@ import math
 from typing import TYPE_CHECKING, Any, Literal
 
 import lightning as pl
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchmetrics
@@ -26,7 +27,10 @@ else:
     from matgl.apps._pes_pyg import Potential  # type: ignore[assignment]
 
 if TYPE_CHECKING:
-    import numpy as np
+    from collections.abc import Iterable, Sequence
+
+    from numpy.typing import ArrayLike
+    from pymatgen.core import Structure
     from torch.optim import Optimizer
     from torch.optim.lr_scheduler import LRScheduler
 
@@ -656,6 +660,100 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
             "Magmom_RMSE": m_rmse,
             "Charge_RMSE": q_rmse,
         }
+
+
+def fit_element_refs(
+    structures: Iterable[Structure],
+    energies: ArrayLike,
+    element_types: Sequence[str],
+    *,
+    rcond: float | None = None,
+) -> np.ndarray:
+    r"""Fit per-element energy offsets via linear regression.
+
+    Solves the least-squares problem
+
+    .. math::
+
+        E_i \approx \sum_{Z \in S} \mu_Z \, N_{i,Z}
+
+    where :math:`E_i` is the total energy of structure :math:`i`,
+    :math:`N_{i,Z}` is the count of element :math:`Z` in that structure,
+    and :math:`\mu_Z` is the per-element offset returned in the same
+    order as ``element_types``. The result is shaped to drop straight
+    into :class:`PotentialLightningModule` or
+    :class:`matgl.apps.pes.Potential` as ``element_refs``.
+
+    Subtracting these offsets from the targets removes the (usually
+    dominant) constant-per-element contribution from the loss so the
+    model only has to learn the relative-energy surface. This stabilises
+    training when the absolute energy scale (~tens of eV per atom) is
+    large compared to the residual variation across a chemically
+    homogeneous training set.
+
+    Args:
+        structures: Iterable of pymatgen ``Structure`` (or ``Molecule``)
+            objects. Composition is read via ``site.specie.symbol``.
+        energies: Total potential energies, one per structure, in any
+            unit consistent with downstream training (usually eV).
+        element_types: Element ordering used by the model — typically
+            the value of ``model.element_types`` or what
+            ``matgl.ext.pymatgen.get_element_list`` returns. The output
+            offset vector is in this order.
+        rcond: Forwarded to ``numpy.linalg.lstsq``. ``None`` (default)
+            uses NumPy's current default cutoff for small singular
+            values; pass ``-1`` to retain old behaviour, or a float to
+            override.
+
+    Returns:
+        ``np.ndarray`` of shape ``(len(element_types),)`` with the fitted
+        per-element offsets, dtype ``float64``.
+
+    Raises:
+        ValueError: If ``structures`` and ``energies`` have different
+            lengths, or if a structure contains an element not listed in
+            ``element_types``.
+
+    Note:
+        For inputs already in graph form (e.g. an
+        :class:`~matgl.graph._data_pyg.MGLDataset` of PyG ``Data``
+        objects), :meth:`matgl.layers.AtomRef.fit` provides the same
+        regression directly on the layer.
+
+    Example:
+        >>> from matgl.ext.pymatgen import get_element_list
+        >>> elements = get_element_list(structures)
+        >>> refs = fit_element_refs(structures, energies, elements)
+        >>> module = PotentialLightningModule(model=model, element_refs=refs)
+    """
+    element_types = tuple(element_types)
+    if not element_types:
+        raise ValueError("element_types must be non-empty.")
+
+    z_to_col = {sym: i for i, sym in enumerate(element_types)}
+    structures_list = list(structures)
+    energies_arr = np.asarray(energies, dtype=np.float64).reshape(-1)
+
+    if len(structures_list) != energies_arr.shape[0]:
+        raise ValueError(
+            f"len(structures)={len(structures_list)} does not match len(energies)={energies_arr.shape[0]}."
+        )
+    if not structures_list:
+        raise ValueError("structures must be non-empty.")
+
+    counts = np.zeros((len(structures_list), len(element_types)), dtype=np.float64)
+    for i, struct in enumerate(structures_list):
+        for site in struct:
+            sym = site.specie.symbol
+            col = z_to_col.get(sym)
+            if col is None:
+                raise ValueError(
+                    f"Structure {i} contains element {sym!r} which is not in element_types={element_types}."
+                )
+            counts[i, col] += 1.0
+
+    refs, *_ = np.linalg.lstsq(counts, energies_arr, rcond=rcond)
+    return refs
 
 
 def xavier_init(model: nn.Module, gain: float = 1.0, distribution: Literal["uniform", "normal"] = "uniform") -> None:

--- a/tests/layers/test_readout_pyg.py
+++ b/tests/layers/test_readout_pyg.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 
 import matgl
 

--- a/tests/layers/test_readout_torch.py
+++ b/tests/layers/test_readout_torch.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 
 from matgl.layers._readout_torch import ReduceReadOut, WeightedAtomReadOut, WeightedReadOut
 

--- a/tests/utils/test_training_pyg.py
+++ b/tests/utils/test_training_pyg.py
@@ -4,6 +4,7 @@ import os
 
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required for deterministic CUDA operations
 
+import contextlib
 import shutil
 from functools import partial
 
@@ -25,6 +26,7 @@ from matgl.models._tensornet_pyg import TensorNet
 from matgl.utils.training import (
     ModelLightningModule,
     PotentialLightningModule,
+    fit_element_refs,
     xavier_init,
 )
 
@@ -166,10 +168,8 @@ class TestModelTrainer:
 
     @classmethod
     def teardown_class(cls):
-        try:
+        with contextlib.suppress(FileNotFoundError):
             shutil.rmtree("lightning_logs")
-        except FileNotFoundError:
-            pass
 
 
 def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
@@ -247,10 +247,8 @@ def test_prediction_logger_train_and_val(LiFePO4, BaNiO3, tmp_path):
     assert torch.equal(on_disk["train_energy_preds"], log["train_energy_preds"])
     assert torch.equal(on_disk["val_energy_preds"], log["val_energy_preds"])
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         shutil.rmtree("lightning_logs")
-    except FileNotFoundError:
-        pass
 
 
 def test_prediction_logger_with_stress_and_charge(LiFePO4, BaNiO3, tmp_path):
@@ -355,10 +353,8 @@ def test_prediction_logger_with_stress_and_charge(LiFePO4, BaNiO3, tmp_path):
     assert "train_stress_preds" not in log_off
     assert "train_charge_preds" not in log_off
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         shutil.rmtree("lightning_logs")
-    except FileNotFoundError:
-        pass
 
 
 def test_prediction_logger_requires_indices(LiFePO4, BaNiO3):
@@ -402,10 +398,8 @@ def test_prediction_logger_requires_indices(LiFePO4, BaNiO3):
     with pytest.raises(RuntimeError, match="add_sample_indices"):
         trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         shutil.rmtree("lightning_logs")
-    except FileNotFoundError:
-        pass
 
 
 def _make_efs_batch():
@@ -569,6 +563,74 @@ def test_model_lightning_module_forward_and_step(LiFePO4, BaNiO3):
     assert {"Total_Loss", "MAE", "RMSE"}.issubset(results)
     assert batch_size == preds.numel()
     assert torch.isfinite(results["Total_Loss"])
+
+
+def test_fit_element_refs_recovers_synthetic_offsets():
+    """fit_element_refs should recover offsets used to synthesize energies.
+
+    Uses a small set of bespoke structures whose composition matrix has
+    full column rank so the least-squares system has a unique solution.
+    """
+    elements = ("Li", "Fe", "P", "O")
+    # 4 unknowns; 6 compositionally distinct structures => over-determined and full rank.
+    species_lists = [
+        ["Li", "Li", "Fe", "P", "O"],
+        ["Li", "Fe", "Fe", "O", "O"],
+        ["Li", "P", "P", "O"],
+        ["Fe", "P", "O", "O", "O"],
+        ["Li", "Li", "P", "O", "O"],
+        ["Fe", "Fe", "P", "P", "O"],
+    ]
+    lattice = Lattice.cubic(8.0)
+    structures = []
+    for specs in species_lists:
+        # Random fractional positions are fine — fit_element_refs only sees composition.
+        coords = np.linspace(0.05, 0.95, num=len(specs))[:, None].repeat(3, axis=1)
+        structures.append(Structure(lattice, specs, coords))
+
+    rng = np.random.default_rng(0)
+    true_refs = rng.uniform(-5.0, -1.0, size=len(elements))
+    z_to_col = {sym: i for i, sym in enumerate(elements)}
+    energies = []
+    for s in structures:
+        counts = np.zeros(len(elements))
+        for site in s:
+            counts[z_to_col[site.specie.symbol]] += 1
+        energies.append(float(counts @ true_refs))
+
+    refs = fit_element_refs(structures, energies, elements)
+    assert refs.shape == (len(elements),)
+    np.testing.assert_allclose(refs, true_refs, atol=1e-8)
+
+
+def test_fit_element_refs_drops_into_potential_lightning_module(LiFePO4):
+    """Refs returned by fit_element_refs are accepted by PotentialLightningModule."""
+    elements = get_element_list([LiFePO4])
+    structures = [LiFePO4, LiFePO4.copy()]
+    energies = [-12.3, -12.1]
+    refs = fit_element_refs(structures, energies, elements)
+    assert refs.dtype == np.float64
+    model = TensorNet(element_types=elements, units=8, nblocks=1, num_rbf=8, is_intensive=False)
+    module = PotentialLightningModule(model=model, element_refs=refs)
+    # The Potential wrapper stores refs as torch float buffers via AtomRef.
+    assert module.model.element_refs is not None
+    np.testing.assert_allclose(
+        module.model.element_refs.property_offset.detach().cpu().numpy(),
+        refs.astype(np.float32),
+        atol=1e-6,
+    )
+
+
+def test_fit_element_refs_validates_inputs(LiFePO4):
+    elements = ("Li", "Fe", "P", "O")
+    with pytest.raises(ValueError, match="non-empty"):
+        fit_element_refs([], [], elements)
+    with pytest.raises(ValueError, match="does not match"):
+        fit_element_refs([LiFePO4], [1.0, 2.0], elements)
+    with pytest.raises(ValueError, match="not in element_types"):
+        fit_element_refs([LiFePO4], [1.0], ("Li", "Fe", "P"))  # missing 'O'
+    with pytest.raises(ValueError, match="non-empty"):
+        fit_element_refs([LiFePO4], [1.0], ())
 
 
 @pytest.mark.parametrize("distribution", ["normal", "uniform", "fake"])


### PR DESCRIPTION
## Summary

Adds `matgl.utils.training.fit_element_refs(structures, energies, element_types)` — a free function that fits per-element energy offsets via `np.linalg.lstsq` and returns a numpy array shaped to drop straight into `PotentialLightningModule(element_refs=...)` or `Potential(element_refs=...)`.

## Why

When training a foundation potential on a chemically homogeneous dataset, the absolute energy scale (~tens of eV per atom from the chosen pseudopotential reference) usually dominates the residual variance the model actually needs to learn. Without per-element offsets the loss is overwhelmingly about getting that constant right, which (a) wastes capacity on what is effectively a constant-per-element bias, (b) creates a force/energy-weight pathology where energy gradients dominate and force MAE actively gets worse during training, and (c) interacts badly with normalization layers in some readouts. Subtracting the linear-regression element refs analytically removes that burden.

## Prior art

`matgl.layers.AtomRef` already has a `.fit(graphs, properties)` method that does the same regression on the *graph* form. That covers users who already have an `MGLDataset`. The new helper covers the common case of having `pymatgen.Structure` objects in hand at dataset-construction time, which is the natural call site for computing refs and then passing them to `PotentialLightningModule`.

## API

```python
from matgl.ext.pymatgen import get_element_list
from matgl.utils.training import fit_element_refs, PotentialLightningModule

elements = get_element_list(structures)
refs = fit_element_refs(structures, energies, elements)
module = PotentialLightningModule(model=model, element_refs=refs)
```

Returns `np.ndarray` of shape `(len(element_types),)`, dtype `float64`, in the same element ordering as `element_types`.

## Implementation notes

- Uses `np.linalg.lstsq` rather than the `pinv((X^TX)) X^T y` pattern in `AtomRef.fit` — better numerical conditioning when the composition matrix is ill-conditioned.
- Validates lengths, empty inputs, and unknown elements with descriptive `ValueError`s.
- Docstring cross-references `AtomRef.fit` so users on the graph-form path aren't pushed off the existing primitive.

## Tests

`tests/utils/test_training_pyg.py`:
- `test_fit_element_refs_recovers_synthetic_offsets` — full-rank synthetic system; recovers true offsets to atol=1e-8.
- `test_fit_element_refs_drops_into_potential_lightning_module` — refs round-trip through `PotentialLightningModule.model.element_refs.property_offset`.
- `test_fit_element_refs_validates_inputs` — empty / mismatched-length / unknown-element / empty-element_types all raise.

All 3 pass; pre-commit (ruff, ruff format, mypy, codespell) clean.

## Drive-by

Replaced four pre-existing `try/except FileNotFoundError: pass` blocks in `tests/utils/test_training_pyg.py` with `contextlib.suppress(FileNotFoundError)` so ruff (SIM105) is clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)