### PR TITLE
perf(pyg): lower-overhead Potential and AtomRef forward paths

### DIFF
--- a/src/matgl/apps/_pes_pyg.py
+++ b/src/matgl/apps/_pes_pyg.py
@@ -28,6 +28,13 @@ class Potential(nn.Module, IOMixIn):
 
     __version__ = 3
 
+    # Class-level annotations narrow ``nn.Module.__getattr__``'s ``Tensor | Module``
+    # return type to ``Tensor`` for these registered buffers, so mypy accepts
+    # ``self.data_mean.device`` and ``self._eye3 + st`` below.
+    data_mean: torch.Tensor
+    data_std: torch.Tensor
+    _eye3: torch.Tensor
+
     def __init__(
         self,
         model: nn.Module,

--- a/src/matgl/apps/_pes_pyg.py
+++ b/src/matgl/apps/_pes_pyg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import torch
@@ -16,6 +17,10 @@ from matgl.utils.io import IOMixIn
 
 if TYPE_CHECKING:
     import numpy as np
+
+# 1 eV/Å³ = 160.21766208 GPa. Stress is autograd of energy w.r.t. strain (eV)
+# divided by volume (Å³), giving eV/Å³; multiply by this constant for GPa.
+EV_PER_ANG3_TO_GPA = 160.21766208
 
 
 class Potential(nn.Module, IOMixIn):
@@ -86,6 +91,9 @@ class Potential(nn.Module, IOMixIn):
 
         self.register_buffer("data_mean", data_mean)
         self.register_buffer("data_std", data_std)
+        # Identity used in strain expansion `lat @ (I + ε)`. Registering as a buffer
+        # avoids allocating a fresh 3x3 every forward and follows .to(device) moves.
+        self.register_buffer("_eye3", torch.eye(3, dtype=matgl.float_th), persistent=False)
 
     def forward(
         self,
@@ -109,7 +117,12 @@ class Potential(nn.Module, IOMixIn):
         Returns:
             (energies, forces, stresses, hessian) or (energies, forces, stresses, hessian, site-wise properties)
         """
-        device = next(self.parameters()).device
+        # Use a registered buffer's device rather than walking parameters every step.
+        # The .to() calls are kept unconditional because PyG ``Data.to()`` returns a
+        # shallow copy — skipping it when on-device would cause the in-place mutations
+        # of ``g.lattice``/``g.pos``/``g.pbc_offshift`` below to leak into the caller's
+        # graph object and break reuse across training steps.
+        device = self.data_mean.device
         g = g.to(device)
         lat = lat.to(device)
         if isinstance(state_attr, torch.Tensor):
@@ -123,7 +136,7 @@ class Potential(nn.Module, IOMixIn):
         if self.calc_stresses:
             st.requires_grad_(True)
 
-        lattice = lat @ (torch.eye(3, device=lat.device) + st)
+        lattice = lat @ (self._eye3 + st)
 
         # Attach lattice to edges
         if isinstance(g, Batch):
@@ -145,25 +158,31 @@ class Potential(nn.Module, IOMixIn):
         if self.calc_forces:
             g.pos.requires_grad_(True)
 
-        total_energies = (
-            self.model(
-                g=g,
-                state_attr=state_attr,
-                l_g=l_g,
-                total_charge=total_charge,
-                ext_pot=ext_pot,
+        # If no derivatives are requested, suppress autograd graph construction entirely.
+        # `calc_stresses` already required `st.requires_grad_(True)` above, so we only
+        # enter the no_grad context when forces/stresses/hessian are all off.
+        needs_autograd = self.calc_forces or self.calc_stresses or self.calc_hessian
+        autograd_ctx = nullcontext() if needs_autograd else torch.no_grad()
+        with autograd_ctx:
+            total_energies = (
+                self.model(
+                    g=g,
+                    state_attr=state_attr,
+                    l_g=l_g,
+                    total_charge=total_charge,
+                    ext_pot=ext_pot,
+                )
+                if self.calc_charge
+                else self.model(g=g, state_attr=state_attr, l_g=l_g)
             )
-            if self.calc_charge
-            else self.model(g=g, state_attr=state_attr, l_g=l_g)
-        )
-        total_energies = self.data_std * total_energies + self.data_mean
+            total_energies = self.data_std * total_energies + self.data_mean
 
-        if self.calc_repuls:
-            total_energies += self.repuls(self.model.element_types, g)
+            if self.calc_repuls:
+                total_energies += self.repuls(self.model.element_types, g)
 
-        if self.element_refs is not None:
-            property_offset = torch.squeeze(self.element_refs(g))
-            total_energies += property_offset
+            if self.element_refs is not None:
+                property_offset = torch.squeeze(self.element_refs(g))
+                total_energies += property_offset
 
         forces = torch.zeros(1)
         stresses = torch.zeros(1)
@@ -171,14 +190,20 @@ class Potential(nn.Module, IOMixIn):
 
         grad_vars = [g.pos, st] if self.calc_stresses else [g.pos]
 
+        # create_graph is only needed if we'll backprop through the gradient itself —
+        # i.e. during training (force-loss double-backward) or for Hessian. At inference
+        # this roughly halves autograd memory and saves wall time. Stress is captured in
+        # the same grad() call as forces, so it does not require retain_graph on its own.
+        needs_double_back = self.training or self.calc_hessian
+
         grads: tuple[torch.Tensor, ...] | None = None
         if self.calc_forces:
             grads = grad(
                 total_energies,
                 grad_vars,
                 grad_outputs=torch.ones_like(total_energies),
-                create_graph=True,
-                retain_graph=True,
+                create_graph=needs_double_back,
+                retain_graph=needs_double_back,
             )
             forces = -grads[0]
 
@@ -187,7 +212,7 @@ class Potential(nn.Module, IOMixIn):
             s = r.size(0)
             hessian = total_energies.new_zeros((s, s))
             for iatom in range(s):
-                tmp = grad([r[iatom]], g.pos, retain_graph=iatom < s)[0]
+                tmp = grad([r[iatom]], g.pos, retain_graph=iatom < s - 1)[0]
                 if tmp is not None:
                     hessian[iatom] = tmp.view(-1)
 
@@ -197,10 +222,14 @@ class Potential(nn.Module, IOMixIn):
                 if matgl.float_th == torch.float16
                 else torch.abs(torch.det(lattice))
             )
+            # grads[1] is dE/dε with shape either (3, 3) [unbatched] or (B, 3, 3) [batched].
+            # Stress = (1/V) * dE/dε in eV/Å³, converted to GPa.
             sts = grads[1]
-            scale = 1.0 / volume * 160.21766208
-            sts = [i * j for i, j in zip(sts, scale, strict=False)] if sts.dim() == 3 else [sts * scale]  # type:ignore[assignment]
-            stresses = torch.cat(sts)  # type:ignore[call-overload]
+            if sts.dim() == 3:
+                scaled = sts * (EV_PER_ANG3_TO_GPA / volume).view(-1, 1, 1)
+                stresses = scaled.reshape(-1, 3)
+            else:
+                stresses = sts * (EV_PER_ANG3_TO_GPA / volume)
 
         if self.debug_mode and grads is not None:
             return total_energies, grads[0], grads[1]

--- a/src/matgl/layers/_atom_ref_pyg.py
+++ b/src/matgl/layers/_atom_ref_pyg.py
@@ -30,7 +30,6 @@ class AtomRef(nn.Module):
 
         self.max_z = property_offset.shape[-1]
         self.register_buffer("property_offset", property_offset)
-        self.register_buffer("onehot", torch.eye(self.max_z))
 
     def get_feature_matrix(self, graphs: list[Data]) -> np.ndarray:
         """Get the number of atoms for different elements in the structure.
@@ -69,19 +68,15 @@ class AtomRef(nn.Module):
         Returns:
             offset_per_graph
         """
-        one_hot = torch.as_tensor(self.onehot)[g.node_type]  # type: ignore[index]
-
+        # Gather per-atom offsets directly: shape (N,) or (S, N) for multi-state refs.
+        # This replaces the previous (N, max_z) one-hot * repeat * multiply * sum pipeline,
+        # which allocated max_z times the memory and FLOPs for the same result.
+        batch = getattr(g, "batch", None)
         if self.property_offset.ndim > 1:
-            offset_batched_with_state_list: list[torch.Tensor] = []
-            for i in range(self.property_offset.size(dim=0)):
-                property_offset_batched = self.property_offset[i].repeat(g.num_nodes, 1).to(one_hot.device)
-                offset = property_offset_batched * one_hot
-                atomic_offset = torch.sum(offset, dim=1)
-                offset_batched = global_add_pool(atomic_offset, g.batch)
-                offset_batched_with_state_list.append(offset_batched)
-            offset_batched_with_state: torch.Tensor = torch.stack(offset_batched_with_state_list)
-            return offset_batched_with_state[state_attr] if state_attr is not None else offset_batched_with_state
-        property_offset_batched = self.property_offset.repeat(g.num_nodes, 1).to(one_hot.device)
-        offset = property_offset_batched * one_hot
-        atomic_offset = torch.sum(offset, dim=1)
-        return global_add_pool(atomic_offset, g.batch)
+            # Multi-state: (S, max_z) -> per-atom (S, N) -> per-graph (S, B)
+            atomic_offset = self.property_offset[:, g.node_type]  # (S, N)
+            offset_per_graph = global_add_pool(atomic_offset.T, batch).T  # (S, B)
+            return offset_per_graph[state_attr] if state_attr is not None else offset_per_graph
+
+        atomic_offset = self.property_offset[g.node_type]  # (N,)
+        return global_add_pool(atomic_offset, batch)  # (B,)


### PR DESCRIPTION
Five behavior-preserving optimizations to the PyG `Potential` and `AtomRef` hot paths. No checkpoint format change, no public-API change, DGL backend untouched.

## Changes

### 1. `AtomRef.forward` — gather instead of one-hot×multiply×sum
Replace the `(N, max_z)` one-hot × repeat × multiply × sum pipeline with a single `self.property_offset[g.node_type]` gather followed by `global_add_pool`. Roughly `max_z×` less memory and FLOPs on every potential call when `element_refs` is set. The multi-state branch (`property_offset.ndim > 1`) collapses to `self.property_offset[:, g.node_type]` followed by pooling, removing the Python `for i in range(n_states)` loop. The `self.onehot` buffer is dropped.

### 2. Conditional `create_graph` / `retain_graph`
`grad(..., create_graph=True, retain_graph=True)` was unconditional. `create_graph` is only needed when the gradient itself is backpropped through — i.e. training (force-loss double-backward) or Hessian. At inference (ASE / MD calculators) this roughly halves autograd memory and saves wall time. Training and Hessian paths are unchanged.

### 3. `no_grad` energy-only fast path
When `calc_forces`, `calc_stresses`, and `calc_hessian` are all False, the model call is wrapped in `torch.no_grad()` so energy-only callers skip the autograd tape entirely.

### 4. Vectorized stress conversion + named constant
Replace `[i * j for i, j in zip(sts, scale)]` + `torch.cat` with `sts * (EV_PER_ANG3_TO_GPA / volume).view(-1, 1, 1)` and a final `reshape(-1, 3)`. `160.21766208` is now `EV_PER_ANG3_TO_GPA` at module scope, with a comment explaining the unit derivation.

### 5. Cache device, register `_eye3` buffer
- `device = next(self.parameters()).device` → `device = self.data_mean.device`. No iterator walk per forward.
- `torch.eye(3, device=lat.device)` allocated per forward → registered once as `self._eye3` (non-persistent buffer).
- The `.to(device)` calls on the graph are kept **unconditional**, on purpose. PyG `Data.to()` returns a shallow copy, and `Potential.forward` mutates `g.lattice` / `g.pos` / `g.pbc_offshift` in place. Skipping the `.to()` when on-device would leak those mutations into the caller's graph object and break reuse across training steps. A clone-on-write follow-up could unlock this skip later.

### Bonus bug fix
The Hessian inner loop had `retain_graph=iatom < s` which is always True (iatom ∈ [0, s)). Corrected to `iatom < s - 1`. Drops one unneeded graph retention on the last iteration.

## Verification
- `uv run pytest tests/apps/test_pes_pyg.py tests/layers/test_atom_ref.py` — **15/15 pass**
- `uv run ruff check src/matgl/apps/_pes_pyg.py src/matgl/layers/_atom_ref_pyg.py` — clean

## Not in this PR (deferred to follow-ups)
- Vectorize the Hessian loop via `torch.func.jacrev` (10–100× speedup on Hessian path)
- DGL twin of these changes
- Clone-on-write for `g` to unlock the device-skip optimization safely
- `torch.compile` wrapping of `self.model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)