### PR TITLE
fix(pyg): Potential.forward no longer mutates the input graph

### DIFF
--- a/src/matgl/apps/_pes_pyg.py
+++ b/src/matgl/apps/_pes_pyg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -143,8 +144,14 @@ class Potential(nn.Module, IOMixIn):
     ) -> tuple[torch.Tensor, ...]:
         """Compute energies, forces, stresses, and (optionally) the Hessian.
 
+        The input ``g`` is **not mutated**: this method shallow-clones it before
+        attaching ``lattice`` / ``pbc_offshift`` / ``pos`` so the same graph can
+        be reused across multiple ``Potential.forward`` calls and shared between
+        callers (e.g. two ``Potential`` instances) without re-conversion.
+
         Args:
-            g: PyG graph
+            g: PyG graph. Read-only — a shallow clone is taken internally so the
+                caller's ``g`` is untouched.
             lat: lattice
             state_attr: State attrs
             l_g: PyG Line graph.
@@ -154,18 +161,23 @@ class Potential(nn.Module, IOMixIn):
         Returns:
             (energies, forces, stresses, hessian) or (energies, forces, stresses, hessian, site-wise properties)
         """
-        # Use a registered buffer's device rather than walking parameters every step.
-        # The .to() calls are kept unconditional because PyG ``Data.to()`` returns a
-        # shallow copy — skipping it when on-device would cause the in-place mutations
-        # of ``g.lattice``/``g.pos``/``g.pbc_offshift`` below to leak into the caller's
-        # graph object and break reuse across training steps.
+        # Shallow-clone the input graph so the in-place attribute assignments below
+        # (``g.lattice`` / ``g.pbc_offshift`` / ``g.pos``) do not leak back to the
+        # caller. PyG's ``Data.to(device)`` migrates tensors in place and returns
+        # ``self``, so it cannot be relied on for isolation. ``copy.copy`` produces
+        # a new ``Data`` with its own attribute namespace but shares tensor refs,
+        # so this is O(1) — the migration cost (if any) is in the ``.to(device)``
+        # call that follows. Skipping the device migration when already co-located
+        # also saves a per-step ``.apply(func)`` walk on the ASE/MD hot path.
         device = self.data_mean.device
-        g = g.to(device)
-        lat = lat.to(device)
-        if isinstance(state_attr, torch.Tensor):
-            state_attr = state_attr.to(device)
-        if l_g is not None:
-            l_g = l_g.to(device)
+        g = copy.copy(g)
+        if lat.device != device:
+            g = g.to(device)
+            lat = lat.to(device)
+            if isinstance(state_attr, torch.Tensor):
+                state_attr = state_attr.to(device)
+            if l_g is not None:
+                l_g = l_g.to(device)
 
         batch_size = g.num_graphs if hasattr(g, "num_graphs") else 1
         # st (strain) for stress calculations

--- a/tests/apps/test_pes_pyg.py
+++ b/tests/apps/test_pes_pyg.py
@@ -145,6 +145,21 @@ class TestPotential:
         fd = (e_plus - e_minus) / (2 * 0.01)
         assert np.allclose(fd.detach().numpy(), grad_dx_zero[0][0].detach().numpy(), atol=1e-05)
 
+    def test_forward_does_not_mutate_input_graph(self, graph_MoS_pyg, model_tensornet):
+        """``Potential.forward`` must shallow-clone ``g`` so the caller's graph keeps
+        its original attribute set and ``frac_coords``/``edge_index`` tensors are
+        not mutated. Regression test: previously ``lattice``/``pbc_offshift``/``pos``
+        leaked back onto the input graph."""
+        structure, graph, state = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+        fields_before = set(graph.keys())
+        ff = Potential(model=model_tensornet)
+        ff(graph, lat, state)
+        fields_after = set(graph.keys())
+        assert fields_before == fields_after, (
+            f"Potential.forward mutated input graph; added: {fields_after - fields_before}"
+        )
+
     def test_potential_with_stress_fd(self, graph_MoS, model_tensornet):
         p2g = Structure2Graph(element_types=("O", "Zr"), cutoff=5.0)
         struct_minus = Structure.from_spacegroup(


### PR DESCRIPTION
Resolves a latent input-mutation issue in `Potential.forward` (PyG) — items 3 + 5 from the optimization audit, addressed together because clone-on-write makes the explicit \"forward mutates the graph\" docstring moot.

## The problem

`Potential.forward` writes three attributes on the graph as part of the strain-aware position rebuild:
```python
g.lattice = lattice[edge_batch]
g.pbc_offshift = (g.pbc_offset.unsqueeze(-1) * g.lattice).sum(dim=1)
g.pos = (g.frac_coords.unsqueeze(-1) * lattice_per_node).sum(dim=1)
```

Pre-PR, those writes leaked back to the caller because PyG's `Data.to(device)` migrates tensors in place and returns `self` — not a fresh `Data` object as the prior code comment claimed. Quick demo against current main:
```
BEFORE forward, g has fields: ['edge_index', 'num_nodes', 'pbc_offset', 'node_type', 'frac_coords']
AFTER  forward, g has fields: ['edge_index', 'num_nodes', 'pbc_offset', 'node_type', 'frac_coords',
                               'lattice', 'pbc_offshift', 'pos']
```

Practical consequences:
1. The same `g` cannot be passed to two `Potential` instances without re-conversion.
2. Callers that snapshot `g` before forward (e.g. for finite-difference probes) see three extra attributes appear after every call.

## The fix

`g = copy.copy(g)` at the top of `forward`. PyG `Data.__copy__` produces a new `Data` with its own `_store` (attribute namespace) but shares tensor references — O(1) and correct. Subsequent `g.lattice = ...` writes go to the local copy and never escape.

As a bonus, the `.to(device)` migration is now conditional on `lat.device != device` — saving a per-step `Data.apply()` walk on the ASE/MD hot path when inputs are already on-device. The same skip was unsafe in #783 precisely because of the mutation issue this PR fixes.

## What's NOT changing
- Output values: bit-clean parity (max |Δforce| = 9.5e-9, max |Δstress| = 9.9e-9, well below the test atols).
- Performance: copy.copy is O(1), so timing is wall-clock-neutral across all modes (energy-only, e+f+s eval, e+f+s train, e+f+s+h).
- DGL backend: untouched. A separate PR addresses the DGL twin.

## Regression test

`tests/apps/test_pes_pyg.py::test_forward_does_not_mutate_input_graph`:
```python
fields_before = set(graph.keys())
ff = Potential(model=model_tensornet)
ff(graph, lat, state)
assert set(graph.keys()) == fields_before
```

Fails on current main (`{lattice, pbc_offshift, pos}` leak in). Passes here.

## Verification

- `uv run mypy -p matgl` — Success: no issues found in 97 source files
- `uv run ruff check src/matgl/apps/_pes_pyg.py tests/apps/test_pes_pyg.py` — clean
- `uv run pytest tests/apps/test_pes_pyg.py tests/layers/test_atom_ref.py` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)