### PR TITLE
docs(training): show how to wire pl loggers and callbacks into MGLPot…

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,30 @@ potential = trainer.fit(dataset=ds, atomrefs=refs, save_path="./MatPES-TensorNet
 
 `MGLDatasetLoader()` defaults to the `materialyze/matpes` HF dataset repo; override `repo_id` / `revision` / `token` / `cache_dir` in the constructor to point at a fork or a private mirror.
 
+#### Logging and callbacks
+
+`MGLPotentialTrainer` instantiates `pl.Trainer` inside `fit()` and forwards everything in `trainer_kwargs` verbatim, so any Lightning `logger` / `callbacks` setup works unchanged. The `PotentialLightningModule` logs `Total_Loss`, `Energy_MAE`, `Force_MAE`, `Stress_MAE` (plus `Magmom_MAE` / `Charge_MAE` when those heads are active) and the matching `*_RMSE` keys, each prefixed with `train_` / `val_` / `test_` — those are the names a checkpoint / early-stopping / logger sees.
+
+```python
+from lightning.pytorch.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger
+
+trainer = MGLPotentialTrainer(
+    model,
+    accelerator="gpu",
+    trainer_kwargs={
+        "logger": CSVLogger(save_dir="./logs", name="matpes-tensornet"),
+        "callbacks": [
+            LearningRateMonitor(logging_interval="epoch"),
+            ModelCheckpoint(dirpath="./logs/ckpts", monitor="val_Total_Loss", mode="min", save_top_k=3),
+            EarlyStopping(monitor="val_Total_Loss", patience=20, mode="min"),
+        ],
+    },
+)
+```
+
+Swap `CSVLogger` for `TensorBoardLogger` / `WandbLogger` / `MLFlowLogger` (or pass a list for multi-sink logging). For per-epoch dumps of every prediction / label / error in stable sample order, matgl ships `matgl.utils.callbacks.PredictionLogger` — stamp the split(s) you want logged with `matgl.utils.callbacks.add_sample_indices` before calling `fit`. For one-off instrumentation, drop a `pl.Callback` subclass into `callbacks`; `PotentialLightningModule.training_step` / `validation_step` return `{"loss", "preds", "labels", "indices", "num_atoms"}` as `outputs` so you can log any derived metric (per-step force RMS, energy residual histograms, etc.) without touching the model.
+
 #### Fine-tune a pre-trained `TensorNet-PES-MatPES-r2SCAN-2025.2`
 
 `matgl.load_model(...)` returns a `Potential` whose inner graph model is `potential.model`. Pass that inner model into `MGLPotentialTrainer` to keep the pretrained weights as the initialisation; pair it with a low learning rate, fewer epochs, and (often) zero or reduced stress weight if the fine-tuning dataset doesn't carry stresses.

--- a/src/matgl/utils/training.py
+++ b/src/matgl/utils/training.py
@@ -1153,6 +1153,64 @@ class MGLPotentialTrainer:
         trainer = MGLPotentialTrainer(model, accelerator="gpu")
         potential = trainer.fit(dataset=ds, atomrefs=refs, save_path="./MatPES-TensorNet")
 
+    **Logging / callbacks.** The trainer instantiates ``pl.Trainer`` inside
+    :meth:`fit` and forwards anything passed via ``trainer_kwargs`` straight
+    to it — Lightning's full ``callbacks`` / ``logger`` vocabulary works
+    unchanged. :class:`PotentialLightningModule` logs ``Total_Loss``,
+    ``Energy_MAE``, ``Force_MAE``, ``Stress_MAE`` (plus ``Magmom_MAE`` /
+    ``Charge_MAE`` when those heads are active) each prefixed with
+    ``train_`` / ``val_`` / ``test_`` and the same set of ``*_RMSE`` keys
+    — those are the names a ``ModelCheckpoint`` / ``EarlyStopping`` /
+    logger sees::
+
+        from lightning.pytorch.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
+        from lightning.pytorch.loggers import CSVLogger
+
+        trainer = MGLPotentialTrainer(
+            model,
+            accelerator="gpu",
+            trainer_kwargs={
+                "logger": CSVLogger(save_dir="./logs", name="matpes-tensornet"),
+                "callbacks": [
+                    LearningRateMonitor(logging_interval="epoch"),
+                    ModelCheckpoint(
+                        dirpath="./logs/ckpts",
+                        monitor="val_Total_Loss",
+                        mode="min",
+                        save_top_k=3,
+                    ),
+                    EarlyStopping(monitor="val_Total_Loss", patience=20, mode="min"),
+                ],
+            },
+        )
+
+    Swap ``CSVLogger`` for ``TensorBoardLogger`` / ``WandbLogger`` /
+    ``MLFlowLogger`` as needed (or pass a list for multi-sink logging).
+
+    For per-epoch dumping of every prediction / label / error in stable
+    sample order, matgl ships :class:`matgl.utils.callbacks.PredictionLogger`
+    (call :func:`matgl.utils.callbacks.add_sample_indices` on the split(s)
+    you want logged before ``fit``). For ad-hoc instrumentation, drop a
+    custom ``pl.Callback`` subclass into ``callbacks``;
+    :meth:`PotentialLightningModule.training_step` /
+    :meth:`~PotentialLightningModule.validation_step` return
+    ``{"loss", "preds", "labels", "indices", "num_atoms"}`` as ``outputs``::
+
+        import lightning.pytorch as pl
+
+        class LogForceRMS(pl.Callback):
+            def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+                force_pred, force_label = outputs["preds"][1], outputs["labels"][1]
+                pl_module.log(
+                    "train_force_rms",
+                    (force_pred - force_label).pow(2).mean().sqrt(),
+                    on_step=True, on_epoch=False,
+                )
+
+        trainer = MGLPotentialTrainer(
+            model, trainer_kwargs={"callbacks": [LogForceRMS()]}
+        )
+
     The trainer is PyG-only; DGL is being deprecated. The class itself
     imports cleanly under DGL but ``fit`` raises informatively when called.
     """
@@ -1219,8 +1277,14 @@ class MGLPotentialTrainer:
             devices: ``pl.Trainer`` device count or selector (e.g. ``1``,
                 ``"auto"``, ``[0, 1]``).
             seed: Forwarded to ``pl.seed_everything(workers=True)`` at fit time.
-            trainer_kwargs: Extra ``pl.Trainer`` kwargs (e.g. ``callbacks``,
-                ``logger``).
+            trainer_kwargs: Extra ``pl.Trainer`` kwargs forwarded verbatim;
+                this is the entry point for Lightning ``callbacks`` and
+                ``logger``. See the *Logging / callbacks* recipe in the class
+                docstring for the canonical
+                ``CSVLogger`` + ``ModelCheckpoint`` + ``EarlyStopping`` setup,
+                the matgl-native :class:`matgl.utils.callbacks.PredictionLogger`,
+                and the metric names (``train_*`` / ``val_*`` / ``test_*``)
+                available to monitor.
             loader_kwargs: Extra kwargs forwarded to :class:`MGLDataLoader` /
                 :func:`split_dataset` via :meth:`_build_dataloaders`.
                 Recognised split-only keys: ``frac_list``, ``shuffle``,


### PR DESCRIPTION
…entialTrainer

Adds a "Logging / callbacks" recipe to the MGLPotentialTrainer class docstring and a mirroring README section. Both spell out the metrics PotentialLightningModule actually publishes (Total_Loss, Energy_MAE, Force_MAE, Stress_MAE, Magmom_MAE, Charge_MAE plus matching *_RMSE, each prefixed with train_/val_/test_), the canonical CSVLogger + ModelCheckpoint(monitor="val_Total_Loss") + LearningRateMonitor + EarlyStopping setup via trainer_kwargs, the matgl-native PredictionLogger (with add_sample_indices) for per-epoch dumps, and a custom pl.Callback example that uses the real outputs dict ({"loss","preds","labels","indices","num_atoms"}) returned by PotentialLightningModule.{training,validation}_step.

The trainer_kwargs arg description is expanded with a pointer to the new recipe so the API doc surfaces it.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
