### PR TITLE
fix: size TensorNet RBF layers correctly for non-smooth SphericalBessel

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -8,6 +8,7 @@ nav_order: 3
 
 ## 3.0.5
 - **Bug fix: `QET` no longer crashes on single-atom structures.** Bare `torch.squeeze()` calls in `QET.forward` (and in the DGL `LinearQeq` QEq solver) collapsed the size-1 node dimension of a one-atom input to a 0-d scalar, raising `IndexError` inside the PyG `ElectrostaticPotential` and a node-feature shape error on the DGL backend. These now use `.reshape(-1)`, which drops only trailing feature dimensions and never the node dimension.
+- **Bug fix: `TensorNet` / `QET` no longer crash with the non-smooth `SphericalBessel` radial basis.** With `rbf_type="SphericalBessel"` and `use_smooth=False`, the basis emits `max_l * max_n` features, but the embedding / interaction input `Linear` layers were sized for only `max_n`, raising a shape-mismatch `RuntimeError` in the forward pass. The radial-basis width fed to those layers now correctly accounts for `max_l` in the non-smooth case (the smooth `SphericalBessel` and `Gaussian` bases are unaffected). Fixed on both the PyG and DGL backends.
 
 ## 3.0.4
 - **PyG `SO3Net`.** New `matgl.models._so3net_pyg.SO3Net` is the PyG counterpart of the existing DGL

--- a/src/matgl/models/_tensornet_dgl.py
+++ b/src/matgl/models/_tensornet_dgl.py
@@ -151,9 +151,13 @@ class TensorNet(MatGLModel):
         self.ntypes_state = ntypes_state
         self.task_type = task_type
 
-        # make sure the number of radial basis functions correct for tensor embedding
+        # The radial-basis width fed to the embedding / interaction layers must match
+        # the actual SphericalBessel output: the smooth basis emits ``max_n`` features,
+        # the non-smooth basis emits ``max_l * max_n`` (one ``max_n``-wide block per
+        # angular order l). Using ``max_n`` for the non-smooth case sized the input
+        # Linear layers too small and crashed the forward pass with a shape mismatch.
         if rbf_type == "SphericalBessel":
-            num_rbf = max_n
+            num_rbf = max_n if use_smooth else max_l * max_n
 
         self.tensor_embedding = TensorEmbedding(
             units=units,

--- a/src/matgl/models/_tensornet_pyg.py
+++ b/src/matgl/models/_tensornet_pyg.py
@@ -168,9 +168,13 @@ class TensorNet(MatGLModel):
         self.ntypes_state = ntypes_state
         self.task_type = task_type
 
-        # make sure the number of radial basis functions correct for tensor embedding
+        # The radial-basis width fed to the embedding / interaction layers must match
+        # the actual SphericalBessel output: the smooth basis emits ``max_n`` features,
+        # the non-smooth basis emits ``max_l * max_n`` (one ``max_n``-wide block per
+        # angular order l). Using ``max_n`` for the non-smooth case sized the input
+        # Linear layers too small and crashed the forward pass with a shape mismatch.
         if rbf_type == "SphericalBessel":
-            num_rbf = max_n
+            num_rbf = max_n if use_smooth else max_l * max_n
 
         EmbeddingCls = TensorEmbeddingWarp if self._use_warp else TensorEmbeddingPyG  # type: ignore[assignment]
         InteractionCls = TensorNetInteractionWarp if self._use_warp else TensorNetInteractionPyG  # type: ignore[assignment]

--- a/tests/models/test_tensornet.py
+++ b/tests/models/test_tensornet.py
@@ -74,6 +74,22 @@ def test_model(graph_MoS):
     _check_scalar_output(output)
 
 
+@pytest.mark.parametrize("use_smooth", [True, False])
+def test_model_spherical_bessel(graph_MoS, use_smooth):
+    """SphericalBessel RBF must size the embedding/interaction layers correctly.
+
+    The non-smooth basis emits ``max_l * max_n`` features (the smooth one emits
+    ``max_n``); a regression test that the input Linear layers are sized to match.
+    """
+    torch.manual_seed(0)
+    _, graph, _ = graph_MoS
+    model = _make_tensornet(is_intensive=False, rbf_type="SphericalBessel", use_smooth=use_smooth, max_n=4, max_l=3)
+    if BACKEND == "PYG":
+        model.to(_device_of(graph))
+    output = model(g=graph)
+    _check_scalar_output(output)
+
+
 def test_exceptions():
     with pytest.raises(ValueError, match="Invalid activation type"):
         _ = _make_tensornet(element_types=None, is_intensive=False, activation_type="whatever")


### PR DESCRIPTION
The non-smooth SphericalBessel basis emits max_l * max_n features (one max_n-wide block per angular order l), but TensorNet sized the embedding and interaction input Linear layers for only max_n, crashing the forward pass with a shape-mismatch RuntimeError. The radial-basis width now accounts for max_l in the non-smooth case; the smooth SphericalBessel and Gaussian bases are unchanged. Applied to both the PyG and DGL backends, with a regression test covering both smooth and non-smooth.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
