### PR TITLE
ci: GPU runner matrix for warp vs eager vs JAX TensorNet benchmark

### DIFF
--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -1,0 +1,196 @@
+name: GPU Benchmark (TensorNet)
+
+# Runs the warp vs eager vs JAX TensorNet inference benchmark on a GPU runner.
+# Manually triggered to avoid burning GPU minutes on every push. The matrix
+# fans out across the three inference backends; the aggregator job downloads
+# each cell's JSON output and prints a combined speedup table to the workflow
+# summary.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iters:
+        description: "Steady-state iterations per measurement"
+        default: "20"
+        type: string
+      warmup:
+        description: "Warm-up iterations per measurement"
+        default: "5"
+        type: string
+      include_xlarge:
+        description: "Include the ~1000-atom supercell"
+        default: false
+        type: boolean
+      runner_label:
+        description: "Label of the GPU runner to use (org-managed)"
+        default: "gpu"
+        type: string
+
+jobs:
+  benchmark:
+    # ``runs-on`` references the org-configured GPU runner. GitHub-hosted larger
+    # GPU runners use whatever label the admin assigned (commonly ``gpu`` or
+    # ``linux-nvidia-gpu``). Override via the ``runner_label`` workflow input.
+    runs-on: ${{ inputs.runner_label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [eager, warp, jax]
+    env:
+      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: "python"
+      MATGL_BACKEND: "PYG"
+      # Force JAX to use the GPU; fail loudly if no GPU is available rather
+      # than silently falling back to CPU and reporting bogus speedups.
+      JAX_PLATFORMS: "cuda,cpu"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: GPU info
+        run: |
+          nvidia-smi || (echo "::error::nvidia-smi not available on runner ${{ inputs.runner_label }}" && exit 1)
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.12"
+
+      - name: Virtual env
+        run: uv venv --python 3.12 --clear
+
+      - name: Install matgl (PYG) + variant extras
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          uv sync --upgrade
+          uv pip install -e .
+          case "$VARIANT" in
+            warp)
+              # ``nvalchemi-toolkit-ops`` ships the NVIDIA Warp kernels used by
+              # the warp TensorNet path; required for ``--variant warp`` to
+              # construct the model with warp-accelerated layers.
+              uv pip install -e ".[ops]"
+              ;;
+            jax)
+              uv pip install -e ".[jax]"
+              # The default ``jax>=0.4.30`` wheel is CPU-only. For a meaningful
+              # speedup measurement we need the CUDA build; install the matching
+              # plugin into the same env.
+              uv pip install --upgrade "jax[cuda12]"
+              ;;
+          esac
+
+      - name: Sanity check
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          uv run --no-sync python -c "import torch; assert torch.cuda.is_available(), 'torch.cuda.is_available() is False on the GPU runner'; print('torch', torch.__version__, 'device', torch.cuda.get_device_name(0))"
+          if [ "$VARIANT" = "jax" ]; then
+            uv run --no-sync python -c "import jax; devs = jax.devices(); print('jax', jax.__version__, 'devices', devs); assert any(str(d.platform).lower() in {'cuda','gpu'} for d in devs), f'no GPU device in jax.devices(): {devs}'"
+          fi
+          if [ "$VARIANT" = "warp" ]; then
+            uv run --no-sync python -c "import nvalchemiops; print('nvalchemiops', getattr(nvalchemiops, '__version__', '?'))"
+          fi
+
+      - name: Run benchmark
+        env:
+          VARIANT: ${{ matrix.variant }}
+          ITERS: ${{ inputs.iters }}
+          WARMUP: ${{ inputs.warmup }}
+          XLARGE: ${{ inputs.include_xlarge && '--xlarge' || '' }}
+        run: |
+          # All variants go through the same TensorNet (random weights, fixed
+          # seed) so the per-system timings can be diffed across cells. JAX
+          # picks its own device, so we pass --device cuda only to the torch
+          # variants.
+          DEVICE_ARG=""
+          if [ "$VARIANT" != "jax" ]; then
+            DEVICE_ARG="--device cuda"
+          fi
+          uv run --no-sync python dev/jax_benchmark.py \
+            --variant "$VARIANT" \
+            $DEVICE_ARG \
+            --warmup "$WARMUP" \
+            --iters "$ITERS" \
+            $XLARGE \
+            --json "benchmark-${VARIANT}.json"
+
+      - name: Upload variant timings
+        uses: actions/upload-artifact@v5
+        with:
+          name: gpu-benchmark-${{ matrix.variant }}
+          path: benchmark-${{ matrix.variant }}.json
+          if-no-files-found: error
+
+  summary:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    if: always() && needs.benchmark.result != 'skipped'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all variant timings
+        uses: actions/download-artifact@v5
+        with:
+          path: results
+          pattern: gpu-benchmark-*
+          merge-multiple: true
+
+      - name: Render summary
+        run: |
+          python - <<'PY'
+          import json, os, glob
+
+          rows_by_system = {}
+          meta = {}
+          for path in sorted(glob.glob("results/benchmark-*.json")):
+              variant = path.rsplit("-", 1)[-1].removesuffix(".json")
+              data = json.loads(open(path).read())
+              meta[variant] = data["info"]
+              for r in data["rows"]:
+                  rec = rows_by_system.setdefault(
+                      r["system"], {"atoms": r["atoms"], "edges": r["edges"], "graph_ms": r["graph_ms"]}
+                  )
+                  if variant == "eager":
+                      rec["eager_ms"] = r["eager_ms"]
+                  elif variant == "warp":
+                      rec["warp_ms"] = r["warp_ms"]
+                  elif variant == "jax":
+                      rec["jax_ms"] = r["jax_ms"]
+                      rec["jax_compile_s"] = r["jax_compile_s"]
+
+          def fmt(v, spec):
+              return "n/a" if v is None else format(v, spec)
+
+          def fmt_x(v):
+              return "n/a" if v is None else f"{v:.2f}x"
+
+          lines = []
+          lines.append(f"# GPU TensorNet Benchmark")
+          if meta:
+              first = next(iter(meta.values()))
+              lines.append(f"- model: `{first.get('model', '?')}`")
+              lines.append(f"- torch device: `{first.get('device', '?')}`")
+              if 'jax_devices' in meta.get('jax', {}):
+                  lines.append(f"- jax devices: `{meta['jax']['jax_devices']}`")
+          lines.append("")
+          lines.append("| system | atoms | edges | graph ms | eager ms | warp ms | jax ms | warp speedup | jax speedup |")
+          lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+          for name in sorted(rows_by_system):
+              r = rows_by_system[name]
+              e = r.get("eager_ms"); w = r.get("warp_ms"); j = r.get("jax_ms")
+              ws = (e / w) if (e and w) else None
+              js = (e / j) if (e and j) else None
+              lines.append(
+                  f"| {name} | {r['atoms']} | {r['edges']} | {fmt(r['graph_ms'], '.2f')} | "
+                  f"{fmt(e, '.2f')} | {fmt(w, '.2f')} | {fmt(j, '.2f')} | "
+                  f"{fmt_x(ws)} | {fmt_x(js)} |"
+              )
+          lines.append("")
+          lines.append("_ms/step = one energy+forces+stress eval (lower is better)._")
+          summary = "\n".join(lines)
+          print(summary)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:
+              fh.write(summary)
+          PY

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -23,14 +23,13 @@ on:
         type: boolean
       runner_label:
         description: "Label of the GPU runner to use (org-managed)"
-        default: "gpu"
+        default: "GPU"
         type: string
 
 jobs:
   benchmark:
-    # ``runs-on`` references the org-configured GPU runner. GitHub-hosted larger
-    # GPU runners use whatever label the admin assigned (commonly ``gpu`` or
-    # ``linux-nvidia-gpu``). Override via the ``runner_label`` workflow input.
+    # ``runs-on`` references the org-managed GPU runner (label ``GPU``).
+    # Override via the ``runner_label`` workflow input if the label changes.
     runs-on: ${{ inputs.runner_label }}
     strategy:
       fail-fast: false

--- a/dev/jax_benchmark.py
+++ b/dev/jax_benchmark.py
@@ -1,4 +1,4 @@
-"""Benchmark: JAX/XLA vs eager-PyTorch (vs torch.compile) for TensorNet/QET inference.
+"""Benchmark: JAX/XLA vs eager-PyTorch (vs warp/torch.compile) for TensorNet/QET inference.
 
 Measures the per-step wall time of a full energy + forces + stress evaluation --
 the inner loop of an ASE MD / relaxation -- across system sizes.
@@ -7,14 +7,20 @@ the inner loop of an ASE MD / relaxation -- across system sizes.
     python dev/jax_benchmark.py --model qet --torch-compile --xlarge
     python dev/jax_benchmark.py --pretrained TensorNet-PES-MatPES-r2SCAN-2025.2
 
-Requires the optional ``jax`` extra: ``pip install matgl[jax]``. XLA compile
-latency is reported separately from steady-state throughput.
+    # CI matrix mode: time a single backend on GPU and emit JSON for aggregation.
+    python dev/jax_benchmark.py --variant warp --device cuda --json out.json
+
+Requires the optional ``jax`` extra (``pip install matgl[jax]``) for the JAX
+variant and ``matgl[ops]`` (``nvalchemi-toolkit-ops``) for the warp variant.
+XLA compile latency is reported separately from steady-state throughput.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import time
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -25,7 +31,6 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from matgl.apps.pes import Potential
 from matgl.config import DEFAULT_ELEMENTS
 from matgl.ext.ase import PESCalculator
-from matgl.ext.jax import JAXPESCalculator
 from matgl.models import QET, TensorNet
 
 PROPS = ["energy", "forces", "stress"]
@@ -49,7 +54,9 @@ def make_structures(include_xlarge: bool = False) -> dict[str, Structure]:
     return out
 
 
-def build_potential(model_type: str = "tensornet", seed: int = 0, **compile_kwargs) -> Potential:
+def build_potential(
+    model_type: str = "tensornet", seed: int = 0, use_warp: bool = False, **compile_kwargs
+) -> Potential:
     """A TensorNet/QET (SphericalBessel-smooth) wrapped in a Potential."""
     torch.manual_seed(seed)
     common = {
@@ -57,7 +64,7 @@ def build_potential(model_type: str = "tensornet", seed: int = 0, **compile_kwar
         "units": 64,
         "nblocks": 2,
         "cutoff": 5.0,
-        "use_warp": False,
+        "use_warp": use_warp,
         "rbf_type": "SphericalBessel",
         "use_smooth": True,
         "max_n": 8,
@@ -70,23 +77,66 @@ def build_potential(model_type: str = "tensornet", seed: int = 0, **compile_kwar
     return pot
 
 
-def time_calc(calc, atoms, n_warmup: int, n_iter: int) -> tuple[float, float]:
+def _cuda_sync(device: str) -> None:
+    if device == "cuda" and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def time_calc(calc, atoms, n_warmup: int, n_iter: int, device: str = "cpu") -> tuple[float, float]:
     """Return ``(first_call_seconds, steady_state_seconds_per_step)``."""
+    _cuda_sync(device)
     t0 = time.perf_counter()
     calc.calculate(atoms, PROPS, all_changes)
+    _cuda_sync(device)
     first = time.perf_counter() - t0
     for _ in range(max(0, n_warmup - 1)):
         calc.calculate(atoms, PROPS, all_changes)
+    _cuda_sync(device)
     t0 = time.perf_counter()
     for _ in range(n_iter):
         calc.calculate(atoms, PROPS, all_changes)
+    _cuda_sync(device)
     return first, (time.perf_counter() - t0) / n_iter
 
 
+def _resolve_pot(args, *, use_warp: bool, device: str) -> Potential:
+    """Build (or load) the potential, move to device, optionally enable warp."""
+    if args.pretrained:
+        import matgl
+
+        pot = matgl.load_model(args.pretrained)
+        # Pretrained TensorNet/QET checkpoints expose ``_use_warp``; if the
+        # warp variant was requested against a non-warp checkpoint, bail out
+        # rather than silently producing comparable-looking but wrong numbers.
+        if use_warp and hasattr(pot.model, "_use_warp") and not pot.model._use_warp:
+            raise SystemExit(
+                "--variant=warp with --pretrained requires a checkpoint whose layers were "
+                "built with use_warp=True. Re-load via build_potential() instead."
+            )
+        pot.eval()
+    else:
+        pot = build_potential(args.model, use_warp=use_warp)
+    pot.to(device)
+    return pot
+
+
 def main() -> None:
-    """Run the JAX-vs-eager benchmark and print a summary table."""
+    """Run the variant benchmark(s) and print a summary table."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", choices=["tensornet", "qet"], default="tensornet")
+    parser.add_argument(
+        "--variant",
+        choices=["eager", "warp", "jax", "all"],
+        default="all",
+        help="Backend(s) to time. 'all' runs every variant available; the others run only that one"
+        " and emit a single-column table (CI/matrix mode).",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Torch device for the eager and warp variants. JAX uses its own device picker.",
+    )
     parser.add_argument("--torch-compile", action="store_true", help="also benchmark torch.compile")
     parser.add_argument("--xlarge", action="store_true", help="include the ~1000-atom cell")
     parser.add_argument("--warmup", type=int, default=3)
@@ -96,88 +146,170 @@ def main() -> None:
         default=None,
         help="load a pretrained model by name (e.g. TensorNet-PES-MatPES-r2SCAN-2025.2) instead of random weights",
     )
+    parser.add_argument(
+        "--json",
+        default=None,
+        help="If set, write the per-system timings to this JSON path for downstream aggregation.",
+    )
     args = parser.parse_args()
 
-    import jax
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("--device=cuda requested but torch.cuda.is_available() is False")
 
-    if args.pretrained:
-        import matgl
+    want = {"eager", "warp", "jax"} if args.variant == "all" else {args.variant}
 
-        pot = matgl.load_model(args.pretrained)
-        pot.eval()
-        label = args.pretrained
-    else:
-        pot = build_potential(args.model)
-        label = f"{args.model} (random weights)"
-    print(f"model: {label}   jax devices: {jax.devices()}   torch threads: {torch.get_num_threads()}")
+    # When ``--variant all`` is used on a machine without ``nvalchemi-toolkit-ops``,
+    # quietly drop the warp variant so the default invocation still produces an
+    # eager-vs-JAX table. An explicit ``--variant warp`` still fails loudly.
+    if args.variant == "all":
+        try:
+            from matgl.models._tensornet_pyg import _warp_available
+        except Exception:
+            _warp_available = False
+        if not _warp_available:
+            want.discard("warp")
+
+    pot_eager = _resolve_pot(args, use_warp=False, device=args.device) if {"eager", "jax"} & want else None
+    pot_warp = _resolve_pot(args, use_warp=True, device=args.device) if "warp" in want else None
+    label = args.pretrained or f"{args.model} (random weights)"
+
+    info = {
+        "model": label,
+        "device": args.device,
+        "variant": args.variant,
+        "torch_threads": torch.get_num_threads(),
+    }
+    if "jax" in want:
+        import jax
+
+        info["jax_devices"] = [str(d) for d in jax.devices()]
+    print(
+        f"model: {label}   variant: {args.variant}   device: {args.device}   "
+        f"torch threads: {torch.get_num_threads()}"
+    )
+    if "jax_devices" in info:
+        print(f"jax devices: {info['jax_devices']}")
 
     rows = []
     for name, struct in make_structures(include_xlarge=args.xlarge).items():
         atoms = AseAtomsAdaptor.get_atoms(struct)
         n_atoms = len(atoms)
+        row: dict = {"system": name, "atoms": n_atoms}
 
-        eager = PESCalculator(pot, stress_unit="GPa")
-        _, eager_ms = time_calc(eager, atoms, args.warmup, args.iters)
-        n_edges = int(eager._atoms2graph.get_graph(atoms)[0].edge_index.shape[1])
-
-        # graph build is CPU-bound (pymatgen neighbour list) and shared by every
-        # backend -- time it on its own so the model speedup can be isolated.
+        # graph-build cost is shared by every backend; always measure it so the
+        # JSON output is self-describing for the aggregator.
+        # Use whichever potential we have to source an Atoms2Graph; both share the
+        # same converter when element_types/cutoff match.
+        ref_calc = PESCalculator(pot_eager or pot_warp, stress_unit="GPa")
+        n_edges = int(ref_calc._atoms2graph.get_graph(atoms)[0].edge_index.shape[1])
         for _ in range(args.warmup):
-            eager._atoms2graph.get_graph(atoms)
+            ref_calc._atoms2graph.get_graph(atoms)
         t0 = time.perf_counter()
         for _ in range(args.iters):
-            eager._atoms2graph.get_graph(atoms)
-        graph_ms = (time.perf_counter() - t0) / args.iters * 1e3
+            ref_calc._atoms2graph.get_graph(atoms)
+        row["edges"] = n_edges
+        row["graph_ms"] = (time.perf_counter() - t0) / args.iters * 1e3
 
-        jax_calc = JAXPESCalculator(pot, stress_unit="GPa")
-        jax_compile, jax_ms = time_calc(jax_calc, atoms, args.warmup, args.iters)
+        if "eager" in want:
+            eager = PESCalculator(pot_eager, stress_unit="GPa")
+            _, t = time_calc(eager, atoms, args.warmup, args.iters, device=args.device)
+            row["eager_ms"] = t * 1e3
+            row["eager_energy"] = float(eager.results["energy"])
+            row["eager_forces"] = eager.results["forces"].tolist()
+        if "warp" in want:
+            warp_calc = PESCalculator(pot_warp, stress_unit="GPa")
+            _, t = time_calc(warp_calc, atoms, args.warmup, args.iters, device=args.device)
+            row["warp_ms"] = t * 1e3
+            row["warp_energy"] = float(warp_calc.results["energy"])
+            row["warp_forces"] = warp_calc.results["forces"].tolist()
+        if "jax" in want:
+            from matgl.ext.jax import JAXPESCalculator
 
-        # correctness guard: JAX must agree with eager within float32 noise
-        ediff = abs(eager.results["energy"] - jax_calc.results["energy"])
-        fdiff = float(np.abs(eager.results["forces"] - jax_calc.results["forces"]).max())
+            jax_calc = JAXPESCalculator(pot_eager, stress_unit="GPa")
+            tc, t = time_calc(jax_calc, atoms, args.warmup, args.iters)
+            row["jax_ms"] = t * 1e3
+            row["jax_compile_s"] = tc
+            row["jax_energy"] = float(jax_calc.results["energy"])
+            row["jax_forces"] = jax_calc.results["forces"].tolist()
 
-        # subtract the shared graph-build cost to isolate the model speedup
-        gb = graph_ms / 1e3
-        model_speedup = (eager_ms - gb) / max(jax_ms - gb, 1e-9)
-        row = {
-            "system": name,
-            "atoms": n_atoms,
-            "edges": n_edges,
-            "graph_ms": graph_ms,
-            "eager_ms": eager_ms * 1e3,
-            "jax_ms": jax_ms * 1e3,
-            "jax_compile_s": jax_compile,
-            "speedup": eager_ms / jax_ms,
-            "model_speedup": model_speedup,
-            "Ediff": ediff,
-            "Fdiff": fdiff,
-        }
-        if args.torch_compile and not args.pretrained:
-            cpot = build_potential(args.model, compile_model=True)
+        if args.torch_compile and not args.pretrained and "eager" in want:
+            cpot = build_potential(args.model, compile_model=True).to(args.device)
             ccalc = PESCalculator(cpot, stress_unit="GPa")
-            _, c_ms = time_calc(ccalc, atoms, max(args.warmup, 3), args.iters)
+            _, c_ms = time_calc(ccalc, atoms, max(args.warmup, 3), args.iters, device=args.device)
             row["tcompile_ms"] = c_ms * 1e3
+
+        # derived comparisons when we have both columns available
+        if {"eager", "jax"} <= want:
+            gb = row["graph_ms"] / 1e3
+            row["speedup_jax_vs_eager"] = (row["eager_ms"] / 1e3) / (row["jax_ms"] / 1e3)
+            row["model_speedup_jax_vs_eager"] = max(row["eager_ms"] / 1e3 - gb, 1e-12) / max(
+                row["jax_ms"] / 1e3 - gb, 1e-12
+            )
+            row["Ediff_jax"] = abs(row["eager_energy"] - row["jax_energy"])
+            row["Fdiff_jax"] = float(
+                np.abs(np.asarray(row["eager_forces"]) - np.asarray(row["jax_forces"])).max()
+            )
+        if {"eager", "warp"} <= want:
+            row["speedup_warp_vs_eager"] = (row["eager_ms"] / 1e3) / (row["warp_ms"] / 1e3)
+            row["Ediff_warp"] = abs(row["eager_energy"] - row["warp_energy"])
+            row["Fdiff_warp"] = float(
+                np.abs(np.asarray(row["eager_forces"]) - np.asarray(row["warp_forces"])).max()
+            )
         rows.append(row)
 
-    hdr = f"{'system':13s}{'atoms':>6s}{'edges':>7s}{'graph ms':>10s}{'eager ms':>10s}{'jax ms':>9s}"
-    hdr += f"{'compile s':>10s}{'speedup':>9s}{'model spd':>10s}"
-    if args.torch_compile:
-        hdr += f"{'tcompile ms':>13s}"
+    _print_table(rows, want, include_tcompile=bool(args.torch_compile and "eager" in want))
+
+    if args.json:
+        # strip the raw force arrays before serialising so the artifact stays small
+        slim = []
+        for r in rows:
+            sr = {k: v for k, v in r.items() if not k.endswith("_forces")}
+            slim.append(sr)
+        Path(args.json).write_text(json.dumps({"info": info, "rows": slim}, indent=2))
+        print(f"wrote {args.json}")
+
+
+def _print_table(rows: list[dict], want: set[str], include_tcompile: bool) -> None:
+    # (key, width, header, fmt) -- fmt is applied via format() on the value
+    cols: list[tuple[str, int, str, str]] = [
+        ("system", 13, "system", "<13s"),
+        ("atoms", 6, "atoms", ">6d"),
+        ("edges", 7, "edges", ">7d"),
+        ("graph_ms", 10, "graph ms", ">10.2f"),
+    ]
+    if "eager" in want:
+        cols.append(("eager_ms", 10, "eager ms", ">10.2f"))
+    if "warp" in want:
+        cols.append(("warp_ms", 10, "warp ms", ">10.2f"))
+    if "jax" in want:
+        cols.append(("jax_ms", 9, "jax ms", ">9.2f"))
+        cols.append(("jax_compile_s", 10, "compile s", ">10.2f"))
+    if include_tcompile:
+        cols.append(("tcompile_ms", 13, "tcompile ms", ">13.2f"))
+    if {"eager", "jax"} <= want:
+        cols.append(("speedup_jax_vs_eager", 9, "jax x", ">9.2f"))
+    if {"eager", "warp"} <= want:
+        cols.append(("speedup_warp_vs_eager", 9, "warp x", ">9.2f"))
+
+    hdr = "".join(f"{label:>{width}s}" for _, width, label, _ in cols)
     print("\n" + hdr)
     print("-" * len(hdr))
     for r in rows:
-        line = f"{r['system']:13s}{r['atoms']:>6d}{r['edges']:>7d}{r['graph_ms']:>10.2f}"
-        line += f"{r['eager_ms']:>10.2f}{r['jax_ms']:>9.2f}{r['jax_compile_s']:>10.2f}"
-        line += f"{r['speedup']:>8.2f}x{r['model_speedup']:>9.2f}x"
-        if "tcompile_ms" in r:
-            line += f"{r['tcompile_ms']:>13.2f}"
+        line = ""
+        for key, width, _label, fmt in cols:
+            v = r.get(key)
+            line += " " * width if v is None else format(v, fmt)
         print(line)
     print()
     print("ms/step = one energy+forces+stress eval (lower is better).")
-    print("speedup = end-to-end vs eager;  model spd = vs eager after subtracting graph build.")
-    maxe = max(r["Ediff"] for r in rows)
-    maxf = max(r["Fdiff"] for r in rows)
-    print(f"parity vs eager (float32): max |dE| {maxe:.2e} eV, max |dF| {maxf:.2e} eV/A")
+    if {"eager", "jax"} <= want:
+        maxe = max(r.get("Ediff_jax", 0.0) for r in rows)
+        maxf = max(r.get("Fdiff_jax", 0.0) for r in rows)
+        print(f"parity jax vs eager (float32): max |dE| {maxe:.2e} eV, max |dF| {maxf:.2e} eV/A")
+    if {"eager", "warp"} <= want:
+        maxe = max(r.get("Ediff_warp", 0.0) for r in rows)
+        maxf = max(r.get("Fdiff_warp", 0.0) for r in rows)
+        print(f"parity warp vs eager:          max |dE| {maxe:.2e} eV, max |dF| {maxf:.2e} eV/A")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/gpu_benchmark.yml` — a `workflow_dispatch`-triggered matrix (`variant: [eager, warp, jax]`) that runs on the org-managed `GPU` runner. Each cell installs the right extras (`matgl[ops]` for warp; `matgl[jax]` + `jax[cuda12]` for JAX), times one backend on a deterministic TensorNet, and uploads a JSON artifact.
- Extends `dev/jax_benchmark.py` with `--variant {eager,warp,jax,all}`, `--device {cpu,cuda}`, and `--json PATH`. The script threads `use_warp` through `build_potential` and moves the potential to CUDA when requested. Default `--variant all` auto-skips warp when `nvalchemiops` isn't installed so the local UX is unchanged.
- An aggregator job downloads the three JSONs and renders a combined ms/step + speedup table to `$GITHUB_STEP_SUMMARY`.

## Test plan
- [x] `ruff check src` / `ruff check dev/jax_benchmark.py` clean
- [x] `dev/jax_benchmark.py` smoke-tested locally on CPU for `--variant eager`, `--variant jax`, and default (`all` → eager+jax)
- [x] Workflow YAML parses
- [ ] Trigger the workflow from the Actions tab once merged; confirm `nvidia-smi`, `torch.cuda.is_available()`, JAX GPU device detection, and `nvalchemiops` import all succeed on the `GPU` runner
- [ ] Confirm the summary table renders with all three variant columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)