### PR TITLE
Fix charges output and total_charge handling for QET in PESCalculator and JAX path

### DIFF
--- a/src/matgl/ext/ase.py
+++ b/src/matgl/ext/ase.py
@@ -35,6 +35,7 @@ from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.optimization.neighbors import find_points_in_spheres
 
+import matgl
 from matgl.graph.converters import GraphConverter
 
 try:
@@ -163,7 +164,7 @@ class Atoms2Graph(GraphConverter):
 class PESCalculator(Calculator):
     """Potential calculator for ASE."""
 
-    implemented_properties = ["energy", "free_energy", "forces", "stress", "hessian", "magmoms"]  # noqa:RUF012
+    implemented_properties = ["energy", "free_energy", "forces", "stress", "hessian", "magmoms", "charges"]  # noqa:RUF012
 
     def __init__(
         self,
@@ -172,6 +173,8 @@ class PESCalculator(Calculator):
         stress_unit: Literal["eV/A3", "GPa"] = "GPa",
         stress_weight: float = 1.0,
         use_voigt: bool = False,
+        total_charge: torch.Tensor | None = None,
+        ext_pot: torch.Tensor | None = None,
         **kwargs,
     ):
         """Init PESCalculator with a Potential from matgl.
@@ -183,6 +186,10 @@ class PESCalculator(Calculator):
             stress_unit (str): stress unit either in "GPa" or "eV/A^3". Default: "GPa"
             stress_weight (float): conversion factor from GPa to eV/A^3, if it is set to 1.0, the unit is in GPa
             use_voigt (bool): whether the voigt notation is used for stress output
+            total_charge (tensor): total charge of the structure, consumed only by charge-predicting
+                potentials (calc_charge=True). If None, the sum of atoms.get_initial_charges() is used.
+            ext_pot (tensor): external potential applied to atoms, shape (Natoms,), consumed only by
+                charge-predicting potentials
             **kwargs: Kwargs pass through to super().__init__().
         """
         super().__init__(**kwargs)
@@ -221,6 +228,8 @@ class PESCalculator(Calculator):
         self.element_types: tuple[str, ...] = potential.model.element_types  # type: ignore[assignment,union-attr,attr-defined]
         self.cutoff: float = potential.model.cutoff  # type: ignore[assignment,union-attr,attr-defined]
         self.use_voigt = use_voigt
+        self.total_charge = total_charge
+        self.ext_pot = ext_pot
         self._atoms2graph = Atoms2Graph(self.element_types, self.cutoff)
 
     def calculate(  # type:ignore[override]
@@ -242,10 +251,16 @@ class PESCalculator(Calculator):
         system_changes = system_changes or all_changes
         super().calculate(atoms=atoms, properties=properties, system_changes=system_changes)
         graph, lattice, state_attr_default = self._atoms2graph.get_graph(atoms)
-        if self.state_attr is not None:
-            calc_result = self.potential(graph, lattice, self.state_attr)
+        state_attr = self.state_attr if self.state_attr is not None else state_attr_default
+        if self.compute_charge:
+            total_charge = (
+                self.total_charge
+                if self.total_charge is not None
+                else torch.tensor(atoms.get_initial_charges(), dtype=matgl.float_th).sum()
+            )
+            calc_result = self.potential(graph, lattice, state_attr, total_charge=total_charge, ext_pot=self.ext_pot)
         else:
-            calc_result = self.potential(graph, lattice, state_attr_default)
+            calc_result = self.potential(graph, lattice, state_attr)
         energy_val = calc_result[0].detach().cpu().numpy().item()
         self.results.update(
             energy=energy_val,
@@ -264,6 +279,11 @@ class PESCalculator(Calculator):
             self.results.update(hessian=calc_result[3].detach().cpu().numpy())
         if self.compute_magmom:
             self.results.update(magmoms=calc_result[4].detach().cpu().numpy())
+        if self.compute_charge:
+            # Potential output layout is (..., charges) with calc_charge alone, but
+            # (..., charges, magmoms) when calc_magmom is also enabled; the magmoms
+            # branch above would then need index 5. No current model sets both flags.
+            self.results.update(charges=calc_result[4].detach().cpu().numpy())
 
 
 # for backward compatibility

--- a/src/matgl/ext/jax/__init__.py
+++ b/src/matgl/ext/jax/__init__.py
@@ -12,7 +12,8 @@ It requires the optional ``jax`` dependency::
 Public entry points:
 
 * :func:`~matgl.ext.jax._convert.convert_potential` -- torch ``Potential`` -> JAX pytree.
-* :func:`~matgl.ext.jax._potential.make_potential_fn` -- jitted ``(E, forces, stress)`` fn.
+* :func:`~matgl.ext.jax._potential.make_potential_fn` -- jitted ``(E, forces, stress)`` fn
+  (optionally + QEq charges for QET).
 * :class:`~matgl.ext.jax._calculator.JAXPESCalculator` -- ASE calculator, a twin of
   ``matgl.ext.ase.PESCalculator``.
 """

--- a/src/matgl/ext/jax/_calculator.py
+++ b/src/matgl/ext/jax/_calculator.py
@@ -3,8 +3,8 @@
 ``JAXPESCalculator`` is a near drop-in twin of ``matgl.ext.ase.PESCalculator``:
 it reuses matgl's existing (numpy/CPU) neighbour-list build, pads the edge list
 to a bucket capacity for shape-stable XLA compilation, and evaluates a single
-jitted ``(E, forces, stress)`` function. It plugs straight into matgl's
-``MolecularDynamics`` / ``Relaxer``.
+jitted ``(E, forces, stress)`` function (plus QEq charges for charge-predicting
+potentials). It plugs straight into matgl's ``MolecularDynamics`` / ``Relaxer``.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from ._potential import make_potential_fn
 class JAXPESCalculator(Calculator):
     """ASE calculator that runs a converted matgl ``Potential`` under JAX/XLA."""
 
-    implemented_properties = ("energy", "free_energy", "forces", "stress")
+    implemented_properties = ("energy", "free_energy", "forces", "stress", "charges")
 
     def __init__(
         self,
@@ -36,6 +36,7 @@ class JAXPESCalculator(Calculator):
         use_voigt: bool = False,
         dtype: str = "float32",
         pad_edges: bool = True,
+        total_charge: float | None = None,
         **kwargs,
     ):
         """Initialize from a (converted-on-the-fly) matgl ``Potential``.
@@ -48,11 +49,16 @@ class JAXPESCalculator(Calculator):
             dtype: ``"float32"`` (default) or ``"float64"``.
             pad_edges: pad the edge list to a bucket capacity so the jitted
                 program is shape-stable across MD steps.
+            total_charge: total charge of the structure, consumed only by charge-predicting
+                potentials (calc_charge=True). If None, the sum of atoms.get_initial_charges()
+                is used.
             **kwargs: forwarded to ``ase.calculators.calculator.Calculator``.
         """
         super().__init__(**kwargs)
         params, cfg, extras = convert_potential(potential)
-        self._fn = make_potential_fn(params, cfg, extras, num_graphs=1)
+        self.compute_charge = bool(getattr(potential, "calc_charge", False))
+        self.total_charge = total_charge
+        self._fn = make_potential_fn(params, cfg, extras, num_graphs=1, with_charges=self.compute_charge)
         self.element_types = tuple(potential.model.element_types)
         self.cutoff = float(potential.model.cutoff)
         self._a2g = Atoms2Graph(self.element_types, self.cutoff)
@@ -91,7 +97,16 @@ class JAXPESCalculator(Calculator):
         else:
             edge_mask = jnp.ones(n_edges, dtype=dt)
 
-        e, f, s = self._fn(pos, strain, frac, lat3, pbc_offset, z, edge_index, batch, edge_mask)
+        charges = None
+        if self.compute_charge:
+            total_charge = (
+                float(self.total_charge) if self.total_charge is not None else atoms.get_initial_charges().sum()
+            )
+            e, f, s, charges = self._fn(
+                pos, strain, frac, lat3, pbc_offset, z, edge_index, batch, edge_mask, jnp.asarray(total_charge, dt)
+            )
+        else:
+            e, f, s = self._fn(pos, strain, frac, lat3, pbc_offset, z, edge_index, batch, edge_mask)
 
         energy = float(np.asarray(e).reshape(-1)[0])
         self.results.update(energy=energy, free_energy=energy, forces=np.asarray(f, dtype=np.float64))
@@ -99,3 +114,5 @@ class JAXPESCalculator(Calculator):
         if self.use_voigt:
             stress = full_3x3_to_voigt_6_stress(stress)
         self.results.update(stress=stress * self.conversion_factor)
+        if charges is not None:
+            self.results.update(charges=np.asarray(charges, dtype=np.float64))

--- a/src/matgl/ext/jax/_potential.py
+++ b/src/matgl/ext/jax/_potential.py
@@ -11,57 +11,84 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
-from ._qet import qet_energy
+from ._qet import qet_energy, qet_energy_and_charges
 from ._tensornet import scatter_add, tensornet_energy
 
 # 1 eV/A^3 = 160.21766208 GPa (matches matgl.apps._pes.EV_PER_ANG3_TO_GPA).
 EV_PER_ANG3_TO_GPA = 160.21766208
 
 
-def make_potential_fn(params, cfg, extras, num_graphs: int = 1, energy_model=None):
+def make_potential_fn(params, cfg, extras, num_graphs: int = 1, energy_model=None, with_charges: bool = False):
     """Build a jitted ``(E, forces, stress)`` function for a converted model.
 
     The returned callable takes ``(pos, strain, frac_coords, lat3, pbc_offset, z,
     edge_index, batch, edge_mask)`` and returns energy (eV), forces (eV/A) and the
     3x3 stress (GPa). ``cfg`` / ``num_graphs`` / denorm constants are closed over.
 
+    With ``with_charges=True`` (converted QET models only) the callable takes one
+    extra trailing argument, a per-batch ``total_charge`` scalar, and additionally
+    returns the QEq per-atom charges: ``(E, forces, stress, charges)``.
+    ``total_charge`` is traced, so varying it does not trigger recompilation.
+
     Forces and stress correspond exactly to ``Potential.forward``'s two autograd
     leaves: ``pos`` carries the force gradient, while ``strain`` deforms *both*
     the PBC offshift and the atomic positions (via ``frac_coords``), so the stress
     captures the full position-deformation term.
     """
+    is_qet = energy_model is None and cfg.get("model_type") == "QET"
+    if with_charges and not is_qet:
+        raise ValueError("with_charges=True requires a converted QET model (charges come from its QEq solve).")
     if energy_model is None:
-        energy_model = qet_energy if cfg.get("model_type") == "QET" else tensornet_energy
+        energy_model = qet_energy if is_qet else tensornet_energy
     data_mean = extras["data_mean"]
     data_std = extras["data_std"]
     element_refs = extras.get("element_refs")
 
-    def total_energy(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask):
+    def total_energy(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge):
         eye = jnp.eye(3, dtype=pos.dtype)
         lattice = lat3 @ (eye + strain)
         pbc_offshift = pbc_offset @ lattice
         # pos == frac_coords @ lat3 (strain == 0); the correction term makes
         # `strain` deform positions too, matching torch's downstream g.pos node.
         pos_corr = pos + frac_coords @ (lattice - lat3)
-        e_model = energy_model(params, cfg, z, pos_corr, edge_index, pbc_offshift, batch, num_graphs, edge_mask)
+        if is_qet:
+            e_model, charges = qet_energy_and_charges(
+                params, cfg, z, pos_corr, edge_index, pbc_offshift, batch, num_graphs, edge_mask, total_charge
+            )
+        else:
+            e_model = energy_model(params, cfg, z, pos_corr, edge_index, pbc_offshift, batch, num_graphs, edge_mask)
+            charges = None
         e = data_std * e_model + data_mean
         if element_refs is not None:
             ref = element_refs[z]
             e = e + (jnp.sum(ref) if num_graphs == 1 else scatter_add(ref, batch, num_graphs))
-        return e
+        return e, charges
 
-    def energy_sum(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask):
-        return jnp.sum(total_energy(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask))
+    def energy_sum(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge):
+        e, charges = total_energy(
+            pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge
+        )
+        return jnp.sum(e), charges
 
     @jax.jit
-    def run(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask):
-        (e, (d_pos, d_strain)) = jax.value_and_grad(energy_sum, argnums=(0, 1))(
-            pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask
+    def run_aux(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge):
+        ((e, charges), (d_pos, d_strain)) = jax.value_and_grad(energy_sum, argnums=(0, 1), has_aux=True)(
+            pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge
         )
         lattice = lat3 @ (jnp.eye(3, dtype=pos.dtype) + strain)
         volume = jnp.abs(jnp.linalg.det(lattice))
         forces = -d_pos
         stress = d_strain * (EV_PER_ANG3_TO_GPA / volume)
+        return e, forces, stress, charges
+
+    if with_charges:
+        return run_aux
+
+    def run(pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask):
+        total_charge = jnp.asarray(cfg.get("total_charge", 0.0), dtype=pos.dtype)
+        e, forces, stress, _ = run_aux(
+            pos, strain, frac_coords, lat3, pbc_offset, z, edge_index, batch, edge_mask, total_charge
+        )
         return e, forces, stress
 
     return run

--- a/src/matgl/ext/jax/_qet.py
+++ b/src/matgl/ext/jax/_qet.py
@@ -57,8 +57,14 @@ def electrostatic_potential(charge, sigma, pos, edge_index, pbc_offshift, cutoff
     return scatter_add(edge_msg * _COULOMB * edge_mask, src, charge.shape[0])
 
 
-def qet_energy(params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs, edge_mask):
-    """Per-graph QET energy (raw model output, before Potential denorm)."""
+def qet_energy_and_charges(
+    params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs, edge_mask, total_charge=None
+):
+    """Per-graph QET energy plus the QEq per-atom charges.
+
+    ``total_charge`` may be a traced scalar so per-structure charges do not
+    trigger recompilation; ``None`` falls back to the static ``cfg`` value.
+    """
     x = forward_features(params, cfg, z, pos, edge_index, pbc_offshift, edge_mask)
 
     # chi / hardness readouts use fixed activations (SiLU / Softplus), independent
@@ -70,7 +76,9 @@ def qet_energy(params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs,
         hardness = params["hardness_readout"][z]
     sigma = params["sigma"][z]
 
-    charge = linear_qeq(chi, hardness, batch, num_graphs, cfg.get("total_charge", 0.0))
+    if total_charge is None:
+        total_charge = cfg.get("total_charge", 0.0)
+    charge = linear_qeq(chi, hardness, batch, num_graphs, total_charge)
     elec_pot = electrostatic_potential(charge, sigma, pos, edge_index, pbc_offshift, cfg["cutoff"], edge_mask)
 
     feats = [x, charge[:, None], elec_pot[:, None]]
@@ -81,5 +89,10 @@ def qet_energy(params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs,
     atomic = gated_mlp(params["final_layer"], node_feat, activate_last=False).reshape(-1)
 
     if num_graphs == 1:
-        return jnp.sum(atomic)[None]
-    return scatter_add(atomic, batch, num_graphs)
+        return jnp.sum(atomic)[None], charge
+    return scatter_add(atomic, batch, num_graphs), charge
+
+
+def qet_energy(params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs, edge_mask):
+    """Per-graph QET energy (raw model output, before Potential denorm)."""
+    return qet_energy_and_charges(params, cfg, z, pos, edge_index, pbc_offshift, batch, num_graphs, edge_mask)[0]

--- a/tests/ext/test_ase.py
+++ b/tests/ext/test_ase.py
@@ -4,11 +4,14 @@ import os.path
 
 import numpy as np
 import pytest
+import torch
 from ase.build import molecule
 from pymatgen.io.ase import AseAtomsAdaptor
 
 import matgl
+from matgl.apps.pes import Potential
 from matgl.ext.ase import Atoms2Graph, M3GNetCalculator, MolecularDynamics, PESCalculator, Relaxer
+from matgl.models import QET
 
 
 def test_PESCalculator_and_M3GNetCalculator(MoS, caplog):
@@ -105,6 +108,34 @@ def test_PESCalculator_mol(AcAla3NHMe):
     assert isinstance(mol.get_potential_energy(), float)
     assert list(mol.get_forces().shape) == [42, 3]
     np.testing.assert_allclose(mol.get_potential_energy(), -249.194916, atol=1e-3)
+
+
+def test_PESCalculator_charges(MoS):
+    torch.manual_seed(0)
+    adaptor = AseAtomsAdaptor()
+    atoms = adaptor.get_atoms(MoS)  # type: ignore
+    pot = Potential(model=QET(use_warp=False, is_intensive=False), calc_charge=True)
+
+    atoms.calc = PESCalculator(potential=pot, stress_unit="eV/A3")
+    e_neutral = atoms.get_potential_energy()
+    charges = atoms.get_charges()
+    assert charges.shape == (len(atoms),)
+    # QEq constrains the partial charges to sum to the total charge
+    np.testing.assert_allclose(charges.sum(), 0.0, atol=1e-5)
+
+    # initial charges on the Atoms set the QEq total charge
+    charged = atoms.copy()
+    charged.set_initial_charges([1.0, 0.0])
+    charged.calc = PESCalculator(potential=pot, stress_unit="eV/A3")
+    e_charged = charged.get_potential_energy()
+    np.testing.assert_allclose(charged.get_charges().sum(), 1.0, atol=1e-5)
+    assert not np.isclose(e_charged, e_neutral, rtol=0, atol=1e-8)
+
+    # an explicit total_charge overrides the initial charges
+    explicit = atoms.copy()
+    explicit.calc = PESCalculator(potential=pot, stress_unit="eV/A3", total_charge=torch.tensor(1.0))
+    np.testing.assert_allclose(explicit.get_charges(), charged.get_charges(), atol=1e-6)
+    np.testing.assert_allclose(explicit.get_potential_energy(), e_charged, atol=1e-6)
 
 
 def test_Relaxer(MoS):

--- a/tests/ext/test_jax.py
+++ b/tests/ext/test_jax.py
@@ -274,3 +274,61 @@ def test_qet_energy_forces_stress_parity(struct_name, cfg_name):
     assert abs(e_t - e_j) < 1e-6, f"energy: torch={e_t} jax={e_j}"
     assert np.abs(f_t - f_j).max() < 1e-6, f"forces max diff {np.abs(f_t - f_j).max():.2e}"
     assert np.abs(s_t - s_j).max() < 1e-6, f"stress max diff {np.abs(s_t - s_j).max():.2e}"
+
+
+def test_qet_calculator_charges():
+    """JAXPESCalculator exposes QEq charges, honors the total charge, and matches PESCalculator."""
+    from pymatgen.io.ase import AseAtomsAdaptor
+
+    from matgl.ext.ase import PESCalculator
+
+    torch.manual_seed(3)
+    model = QET(
+        element_types=DEFAULT_ELEMENTS,
+        units=32,
+        nblocks=2,
+        cutoff=CUTOFF,
+        use_warp=False,
+        **QET_CONFIGS["gaussian-default"],
+    )
+    model.eval()
+    potential = Potential(model=model, calc_forces=True, calc_stresses=True, calc_charge=True)
+    potential.eval()
+
+    atoms = AseAtomsAdaptor.get_atoms(QET_STRUCTURES["GaAs"])
+    atoms.calc = JAXPESCalculator(potential, stress_unit="GPa")
+    e_neutral = atoms.get_potential_energy()
+    q_neutral = atoms.get_charges()
+    assert q_neutral.shape == (len(atoms),)
+    # QEq constrains the partial charges to sum to the total charge
+    np.testing.assert_allclose(q_neutral.sum(), 0.0, atol=1e-5)
+
+    # parity with the torch PESCalculator (both float32)
+    ref_atoms = atoms.copy()
+    ref_atoms.calc = PESCalculator(potential, stress_unit="GPa")
+    np.testing.assert_allclose(q_neutral, ref_atoms.get_charges(), atol=1e-4)
+
+    # initial charges set the QEq total charge; same calculator instance, so the
+    # traced total_charge argument changes without recompilation
+    charged = atoms.copy()
+    initial = np.zeros(len(charged))
+    initial[0] = 1.0
+    charged.set_initial_charges(initial)
+    charged.calc = atoms.calc
+    e_charged = charged.get_potential_energy()
+    q_charged = charged.get_charges()
+    np.testing.assert_allclose(q_charged.sum(), 1.0, atol=1e-5)
+    assert not np.isclose(e_charged, e_neutral, rtol=0, atol=1e-8)
+
+    # an explicit total_charge overrides the initial charges
+    explicit = atoms.copy()
+    explicit.calc = JAXPESCalculator(potential, stress_unit="GPa", total_charge=1.0)
+    np.testing.assert_allclose(explicit.get_charges(), q_charged, atol=1e-6)
+
+
+def test_make_potential_fn_with_charges_requires_qet():
+    """``with_charges=True`` is rejected for non-QET conversions."""
+    potential, _, _ = _build(TN_STRUCTURES["Si2"], TN_CONFIGS["gaussian-extensive"])
+    params, cfg, extras = convert_potential(potential)
+    with pytest.raises(ValueError, match="requires a converted QET model"):
+        make_potential_fn(params, cfg, extras, num_graphs=1, with_charges=True)


### PR DESCRIPTION

When the DGL backend was removed, the only calculator with charge plumbing went with it. For charge-predicting potentials (QET):

- get_charges() raised PropertyNotImplementedError on both PESCalculator and JAXPESCalculator: "charges" was missing from implemented_properties and never stored in results, even though the torch Potential returns them and the JAX QEq solve computes them.
- total_charge was silently ignored everywhere: the torch calculator never passed it (LinearQeq treats None as zero) and the JAX conversion baked it as a static 0.0, so charged cells ran as neutral with no error. atoms.set_initial_charges(), which the DGL calculator consumed, was also ignored.

Changes:

- PESCalculator: "charges" in implemented_properties, results populated when potential.calc_charge is set, total_charge/ext_pot kwargs restored with the atoms.get_initial_charges() fallback. Relaxer and MolecularDynamics inherit this automatically.
- make_potential_fn(): public (E, forces, stress) 3-tuple contract unchanged by default. with_charges=True (QET only) returns a callable with a trailing total_charge argument that also returns per-atom charges; total_charge is traced, so varying it triggers no recompilation.
- qet_energy_and_charges() returns (energy, charges) and accepts a traced total_charge; qet_energy() stays a thin wrapper.
- JAXPESCalculator mirrors PESCalculator: "charges" exposed, total_charge kwarg with the initial-charges fallback.