### PR TITLE
Add LAMMPS pair_matgl + Kokkos plugin, add GPU CI job

### DIFF
--- a/.github/workflows/lammps-build.yml
+++ b/.github/workflows/lammps-build.yml
@@ -9,9 +9,12 @@ name: LAMMPS pair_matgl build
 #   * gcc/g++/cmake/python3.
 # If any of those are missing the workflow falls back to downloading them.
 #
-# Kokkos / GPU variant is *not* exercised here — GitHub-hosted runners have
-# no GPU. Phase-3 hardware testing is delegated to a self-hosted CUDA
-# runner (TODO).
+# A second job, build_pair_matgl_kokkos, exercises the Kokkos/GPU variant
+# (pair_style matgl/kk). It needs a self-hosted runner labeled
+# [self-hosted, gpu, cuda] with an NVIDIA driver + nvcc on PATH — there is
+# no such runner registered against this repo today, so the job will queue
+# forever until one exists. Verified manually on a single-GPU NERSC node;
+# not yet exercised by this workflow.
 
 on:
   push:
@@ -312,6 +315,285 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lammps-debug
+          path: |
+            matgl/lammps/tests/log.lammps
+            lammps_artifacts/
+            lammps_build/CMakeFiles/CMakeOutput.log
+            lammps_build/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
+
+  build_pair_matgl_kokkos:
+    name: pair_matgl/kk (GPU, Kokkos)
+    # Requires a self-hosted runner with an NVIDIA GPU, driver, and nvcc on
+    # PATH, labeled to match below. No such runner is registered against
+    # this repo yet, so this job will queue indefinitely until one exists.
+    # `timeout-minutes` bounds that queue time instead of hanging forever.
+    runs-on: [self-hosted, gpu, cuda]
+    timeout-minutes: 60
+
+    env:
+      LIBTORCH_VERSION: "2.5.1"
+      # libtorch CUDA wheel tag (e.g. cu118, cu121, cu124) — must match the
+      # CUDA toolkit installed on the runner. Override via repo/org variable
+      # CUDA_TAG if the runner ships a different CUDA version.
+      CUDA_TAG: ${{ vars.CUDA_TAG || 'cu121' }}
+      # Kokkos GPU architecture flag (see Kokkos_ARCH_* options) — must match
+      # the runner's GPU. Override via repo/org variable KOKKOS_ARCH.
+      KOKKOS_ARCH: ${{ vars.KOKKOS_ARCH || 'AMPERE80' }}
+
+    steps:
+      - name: Checkout matgl
+        uses: actions/checkout@v4
+        with:
+          path: matgl
+
+      - name: Probe runner for CUDA + LAMMPS source
+        id: probe
+        shell: bash
+        run: |
+          set -e
+          if ! command -v nvidia-smi >/dev/null 2>&1; then
+              echo "No NVIDIA driver found on this runner (nvidia-smi missing)" >&2
+              exit 1
+          fi
+          nvidia-smi
+          for cand in /opt/lammps /usr/local/src/lammps /lammps "$HOME/lammps"; do
+              if [ -f "$cand/cmake/CMakeLists.txt" ]; then
+                  echo "lammps_src=$cand" >> "$GITHUB_OUTPUT"
+                  echo "Found LAMMPS source at: $cand"
+                  break
+              fi
+          done
+          for cand in /opt/libtorch /usr/local/libtorch /libtorch "$HOME/libtorch"; do
+              if [ -f "$cand/share/cmake/Torch/TorchConfig.cmake" ]; then
+                  echo "libtorch=$cand" >> "$GITHUB_OUTPUT"
+                  echo "Found libtorch at: $cand"
+                  break
+              fi
+          done
+
+      - name: Cache CUDA libtorch (fallback)
+        if: steps.probe.outputs.libtorch == ''
+        id: cache-libtorch
+        uses: actions/cache@v4
+        with:
+          path: libtorch
+          key: libtorch-${{ env.LIBTORCH_VERSION }}-${{ env.CUDA_TAG }}-cxx11abi
+
+      - name: Download CUDA libtorch (fallback)
+        if: steps.probe.outputs.libtorch == '' && steps.cache-libtorch.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -L -o libtorch.zip \
+            "https://download.pytorch.org/libtorch/${CUDA_TAG}/libtorch-cxx11-abi-shared-with-deps-${LIBTORCH_VERSION}%2B${CUDA_TAG}.zip"
+          unzip -q libtorch.zip
+          rm libtorch.zip
+
+      - name: Resolve libtorch path
+        id: libtorch
+        shell: bash
+        run: |
+          if [ -n "${{ steps.probe.outputs.libtorch }}" ]; then
+              echo "path=${{ steps.probe.outputs.libtorch }}" >> "$GITHUB_OUTPUT"
+          else
+              echo "path=${GITHUB_WORKSPACE}/libtorch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Clone LAMMPS (fallback)
+        # Vanilla LAMMPS source ships lib/kokkos/ (incl. bin/nvcc_wrapper)
+        # in-tree — no separate Kokkos checkout needed.
+        if: steps.probe.outputs.lammps_src == ''
+        shell: bash
+        run: |
+          git clone --depth 1 --branch develop \
+              https://github.com/lammps/lammps.git lammps_src
+
+      - name: Resolve LAMMPS source path
+        id: lammps
+        shell: bash
+        run: |
+          if [ -n "${{ steps.probe.outputs.lammps_src }}" ]; then
+              echo "path=${{ steps.probe.outputs.lammps_src }}" >> "$GITHUB_OUTPUT"
+          else
+              echo "path=${GITHUB_WORKSPACE}/lammps_src" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Python deps (uv) for parity reference
+        shell: bash
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          cd matgl
+          uv venv --python 3.12
+          uv pip install -e .
+          uv pip install pytest
+
+      - name: Export tiny LAMMPS-loadable model + Python reference
+        # Same fixture as the CPU job: a 4-atom Mo-S cell, tiny untrained
+        # TensorNet. Export runs on CPU — no GPU needed to build the
+        # TorchScript artifact, only to evaluate it inside LAMMPS later.
+        shell: bash
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          cd matgl
+          mkdir -p ../lammps_artifacts
+          uv run python - <<'PY'
+          import json
+          import numpy as np
+          import torch
+          from pymatgen.core import Lattice, Structure
+          from pymatgen.optimization.neighbors import find_points_in_spheres
+          from matgl.apps._pes_pyg import Potential
+          from matgl.ext._lammps import LAMMPSMatGLModel
+          from matgl.models._tensornet_pyg import TensorNet
+
+          torch.manual_seed(0)
+          m = TensorNet(
+              element_types=("Mo", "S"),
+              is_intensive=False,
+              units=16, nblocks=1, num_rbf=8,
+              cutoff=4.0, use_warp=False, rbf_type="Gaussian",
+          )
+          p = Potential(model=m, calc_forces=True, calc_stresses=True)
+          p.eval()
+          w = LAMMPSMatGLModel(potential=p, dtype=torch.float32)
+          w.eval()
+          torch.jit.script(w).save("../lammps_artifacts/model.pt")
+
+          struct = Structure(
+              Lattice.cubic(4.5),
+              ["Mo", "S", "Mo", "S"],
+              [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0, 0.25], [0, 0.5, 0.75]],
+          )
+          src, dst, images, dist = find_points_in_spheres(
+              struct.cart_coords, struct.cart_coords, r=4.0,
+              pbc=np.array([1, 1, 1], dtype=np.int64),
+              lattice=np.array(struct.lattice.matrix), tol=1e-8,
+          )
+          keep = (src != dst) | (dist > 1e-8)
+          src, dst, images = src[keep], dst[keep], images[keep]
+          pos = torch.tensor(struct.cart_coords, dtype=torch.float32)
+          eidx = torch.tensor(np.stack([src, dst]), dtype=torch.long)
+          ushifts = torch.tensor(images, dtype=torch.long)
+          cell = torch.tensor(np.array(struct.lattice.matrix), dtype=torch.float32)
+          z = torch.tensor([s.specie.Z for s in struct], dtype=torch.long)
+          local = torch.ones(len(struct), dtype=torch.bool)
+          out = w(pos, eidx, ushifts, cell, z, local, True)
+          ref = {
+              "energy": float(out["total_energy_local"].item()),
+              "forces": out["forces"].detach().tolist(),
+          }
+          with open("../lammps_artifacts/reference.json", "w") as fh:
+              json.dump(ref, fh, indent=2)
+          print(json.dumps(ref, indent=2))
+          PY
+
+      - name: Drop ML-MATGL-KOKKOS sources into LAMMPS src/KOKKOS/
+        # src/KOKKOS/ is a *standard* LAMMPS package directory, always
+        # scanned for PairStyle(...) macros when PKG_KOKKOS=ON — unlike
+        # ML-MATGL, it doesn't need RegisterStyles() wired into
+        # CMakeLists.txt by hand (that's only needed on the hand-patched
+        # NERSC checkout this package was developed against). Dropping the
+        # .cpp/.h straight in mirrors the CPU job's src/-root trick.
+        shell: bash
+        env:
+          LAMMPS_SRC: ${{ steps.lammps.outputs.path }}
+        run: |
+          cp matgl/lammps/src/ML-MATGL/pair_matgl.cpp "${LAMMPS_SRC}/src/"
+          cp matgl/lammps/src/ML-MATGL/pair_matgl.h   "${LAMMPS_SRC}/src/"
+          cp matgl/lammps/src/KOKKOS/pair_matgl_kokkos.cpp "${LAMMPS_SRC}/src/KOKKOS/"
+          cp matgl/lammps/src/KOKKOS/pair_matgl_kokkos.h   "${LAMMPS_SRC}/src/KOKKOS/"
+          if ! grep -q ML-MATGL-KOKKOS-CI.cmake "${LAMMPS_SRC}/cmake/CMakeLists.txt"; then
+              echo "include(${GITHUB_WORKSPACE}/matgl/lammps/cmake/ML-MATGL-KOKKOS-CI.cmake)" \
+                  >> "${LAMMPS_SRC}/cmake/CMakeLists.txt"
+          fi
+          # CI-only cmake fragment: just link Torch. The base pair_matgl.cpp
+          # in src/ also needs Torch linked (same as the CPU job); the
+          # Kokkos sources in src/KOKKOS/ are picked up automatically by
+          # LAMMPS' own KOKKOS package glob once PKG_KOKKOS=ON.
+          cat > matgl/lammps/cmake/ML-MATGL-KOKKOS-CI.cmake <<'CM'
+          find_package(Torch REQUIRED)
+          target_compile_features(lammps PRIVATE cxx_std_17)
+          target_link_libraries(lammps PRIVATE ${TORCH_LIBRARIES})
+          if(DEFINED TORCH_CXX_FLAGS)
+              set_property(TARGET lammps APPEND_STRING
+                  PROPERTY COMPILE_FLAGS " ${TORCH_CXX_FLAGS}")
+          endif()
+          message(STATUS "ML-MATGL-KOKKOS (CI): linked against TORCH_LIBRARIES=${TORCH_LIBRARIES}")
+          CM
+
+      - name: Configure LAMMPS (Kokkos/CUDA)
+        shell: bash
+        env:
+          LAMMPS_SRC: ${{ steps.lammps.outputs.path }}
+          LIBTORCH: ${{ steps.libtorch.outputs.path }}
+        run: |
+          BUILD_DIR="${GITHUB_WORKSPACE}/lammps_build"
+          rm -rf "${BUILD_DIR}"
+          cmake -B "${BUILD_DIR}" -S "${LAMMPS_SRC}/cmake" \
+            -G Ninja \
+            -D PKG_KOKKOS=ON \
+            -D Kokkos_ENABLE_CUDA=ON \
+            -D Kokkos_ENABLE_CUDA_LAMBDA=ON \
+            -D Kokkos_ARCH_${KOKKOS_ARCH}=ON \
+            -D CMAKE_CXX_COMPILER="${LAMMPS_SRC}/lib/kokkos/bin/nvcc_wrapper" \
+            -D CMAKE_PREFIX_PATH="${LIBTORCH}" \
+            -D MKL_INCLUDE_DIR=/usr/include \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_MPI=OFF
+
+      - name: Build LAMMPS
+        shell: bash
+        run: |
+          cmake --build "${GITHUB_WORKSPACE}/lammps_build" -j 2
+
+      - name: Run pair_matgl/kk single-point deck on GPU
+        # Same in.matgl_si deck as the CPU job, unmodified — `-sf kk`
+        # dispatches `pair_style matgl` to `matgl/kk` automatically.
+        shell: bash
+        env:
+          LIBTORCH: ${{ steps.libtorch.outputs.path }}
+        run: |
+          export LD_LIBRARY_PATH="${LIBTORCH}/lib:${LD_LIBRARY_PATH:-}"
+          cp lammps_artifacts/model.pt matgl/lammps/tests/model.pt
+          cd matgl/lammps/tests
+          "${GITHUB_WORKSPACE}/lammps_build/lmp" -k on g 1 -sf kk -in in.matgl_si | tee log.lammps
+
+      - name: Diff LAMMPS energy against Python reference
+        shell: bash
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          cd matgl
+          uv run python - <<'PY'
+          import json
+          import sys
+
+          ref = json.load(open("../lammps_artifacts/reference.json"))
+          log = open("lammps/tests/log.lammps").read()
+          # thermo_style for the test deck is "step pe fx fy fz pxx pyy pzz".
+          # With ``run 0`` LAMMPS prints one numeric row; pull its second column.
+          pe = None
+          for line in log.splitlines():
+              cols = line.split()
+              if len(cols) >= 2 and cols[0].lstrip("-").isdigit():
+                  try:
+                      pe = float(cols[1])
+                  except ValueError:
+                      continue
+          assert pe is not None, "Could not find PotEng row in log.lammps"
+          ref_e = ref["energy"]
+          diff = abs(pe - ref_e)
+          print(f"LAMMPS PotEng = {pe!r}, Python ref = {ref_e!r}, diff = {diff:.3e}")
+          if diff > 1e-3:
+              print("ENERGY MISMATCH!", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lammps-kokkos-debug
           path: |
             matgl/lammps/tests/log.lammps
             lammps_artifacts/

--- a/lammps/README.md
+++ b/lammps/README.md
@@ -183,14 +183,23 @@ stresses (when nonzero) within `1e-3 GPa`.
 - The pair style requests a **full neighbor list with ghost atoms**
   (`REQ_FULL | REQ_GHOST`). The model expects edge indices that span both
   owned and ghost atoms.
-- Bond vectors are computed from LAMMPS' already-imaged ghost positions,
-  so `unit_shifts` is always zero — the strain-based stress trick still
-  works because the strain is applied to all atomic positions (owned and
-  ghost) on the model side.
+- Every edge is folded back onto the *local* row of the atom it represents
+  (via `atom->map(atom->tag[j])`) rather than pointing at the ghost row
+  directly. TensorNet's message-passing layers need one consistent row
+  per physical atom — a ghost row never propagates outgoing messages back
+  to the atom it duplicates. The periodic image is recovered explicitly as
+  an integer `unit_shifts` (the ghost/local position difference,
+  transformed through the box's inverse deformation matrix and rounded to
+  the nearest integer), rather than relying on LAMMPS' already-imaged
+  ghost positions with `unit_shifts = 0`. Single-rank only: ghost atoms
+  can be owned by a different MPI rank, so there is no local row to fold
+  onto in a multi-rank run.
 - Forces are accumulated for **all** atoms (owned + ghost). LAMMPS' usual
   `comm->reverse_comm` step then sums ghost contributions back to the
   rank that owns each atom. This requires `newton on`.
-- Virials are written into the global `virial[6]` array directly. We set
+- Virials are written into the global `virial[6]` array directly as
+  `virial -= va` (the model returns `virials = dE/dstrain = -W`, while
+  LAMMPS' convention is `W = sum_i r_i ⊗ f_i`). We set
   `no_virial_fdotr_compute = 1` in the constructor so LAMMPS doesn't
   recompute the virial from forces.
 

--- a/lammps/src/KOKKOS/pair_matgl_kokkos.cpp
+++ b/lammps/src/KOKKOS/pair_matgl_kokkos.cpp
@@ -10,9 +10,12 @@
 
      * the model forward signature (we pass `compute_virials: bool`),
      * the output dict keys (`total_energy_local`, `forces`, `virials`),
-     * `unit_shifts` is held at zero because LAMMPS hands us already-imaged
-       ghost positions; the strain-grad still propagates correctly because
-       the wrapper applies the strain to *every* position (owned and ghost).
+     * every edge is folded back onto a *local* row (via `local_row_of_`)
+       with a recovered integer `unit_shifts`, rather than pointing at the
+       ghost row directly -- TensorNet's message-passing layers need one
+       consistent row per physical atom, and a ghost row never propagates
+       outgoing messages back to the atom it duplicates (see pair_matgl.cpp
+       for the full explanation and how the shift is recovered).
 
    Caveats on multi-rank Kokkos with libtorch (mirroring MACE):
      * Single-GPU runs are the supported configuration.
@@ -73,7 +76,8 @@ void PairMATGLKokkos<DeviceType>::init_style()
 
   // Pick the matching libtorch device.
   if (std::is_same<DeviceType, Kokkos::Cuda>::value) {
-    const int gpu = lmp->kokkos->ngpus > 0 ? lmp->kokkos->local_rank : 0;
+    int gpu = 0;
+    if (lmp->kokkos->ngpus > 0) cudaGetDevice(&gpu);
     torch_device_ = torch::Device(torch::kCUDA, gpu);
   } else {
     torch_device_ = torch::kCPU;
@@ -131,6 +135,14 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
   auto f = atomKK->k_f.template view<DeviceType>();
   auto type = atomKK->k_type.template view<DeviceType>();
 
+  if (comm->nprocs > 1)
+    error->all(FLERR,
+               "pair_style matgl/kk: multi-rank (MPI-decomposed) runs are "
+               "not yet supported -- ghost atoms may be owned by a "
+               "different rank, so there is no local row to fold periodic "
+               "edges back onto. Run with a single MPI rank (`-k on g 1` "
+               "single-GPU is the supported configuration).");
+
   const int inum = list->inum;
   const int nall = atom->nlocal + atom->nghost;
   const int nlocal = atom->nlocal;
@@ -147,6 +159,9 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:Z"), atom_capacity_);
     d_local_or_ghost_ = Kokkos::View<bool *, DeviceType>(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:mask"),
+        atom_capacity_);
+    d_local_row_of_ = Kokkos::View<int *, DeviceType>(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:localrow"),
         atom_capacity_);
     d_numneigh_short_ = Kokkos::View<int *, DeviceType>(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:nshort"),
@@ -166,6 +181,25 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
         d_atomic_numbers_(i) = type_to_z(t);
         d_local_or_ghost_(i) = (i < nlocal);
       });
+
+  // local_row_of_(j) = the owned row representing the same physical atom as
+  // row j (identity for local rows; the owned copy with the same tag for
+  // ghosts). atom->map() is a host-only lookup, and `nall` is small (a few
+  // thousand atoms) next to the GPU model forward pass below, so we just
+  // build this on the host once per compute() call. See pair_matgl.cpp for
+  // why every edge must resolve to one consistent row per atom.
+  atomKK->sync(Host, TAG_MASK);
+  auto h_local_row_of = Kokkos::create_mirror_view(d_local_row_of_);
+  for (int j = 0; j < nall; ++j) {
+    const int j_local = atom->map(atom->tag[j]);
+    if (j_local < 0 || j_local >= nlocal)
+      error->one(FLERR,
+                 "pair_style matgl/kk: could not resolve atom {} (tag {}) "
+                 "to a local row -- is `atom_modify map yes` set?",
+                 j, atom->tag[j]);
+    h_local_row_of(j) = j_local;
+  }
+  Kokkos::deep_copy(d_local_row_of_, h_local_row_of);
 
   // 2) Count short-cutoff neighbors per i (only inum atoms are listed,
   //    so initialize numneigh_short_ for ghost atoms to zero).
@@ -209,15 +243,22 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
 
   if (total_edges > edge_capacity_) {
     edge_capacity_ = total_edges;
-    d_edge_index_ = Kokkos::View<int64_t **, DeviceType>(
+    d_edge_index_ = Kokkos::View<int64_t **, Kokkos::LayoutRight, DeviceType>(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:edges"), 2,
         edge_capacity_);
-    d_unit_shifts_ = Kokkos::View<int64_t **, DeviceType>(
+    d_unit_shifts_ = Kokkos::View<int64_t **, Kokkos::LayoutRight, DeviceType>(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "matgl:shifts"),
         edge_capacity_, 3);
   }
 
-  // 4) Fill edge_index + unit_shifts.
+  // 4) Fill edge_index + unit_shifts. Every edge must resolve to the local
+  //    row of the atom it represents -- TensorNet's message-passing layers
+  //    need one consistent row per physical atom (periodicity goes through
+  //    unit_shifts, not through ghost-row duplication; see pair_matgl.cpp).
+  const auto d_local_row_of = d_local_row_of_;
+  const double *const h_inv_host = domain->h_inv;
+  const double hinv0 = h_inv_host[0], hinv1 = h_inv_host[1], hinv2 = h_inv_host[2];
+  const double hinv3 = h_inv_host[3], hinv4 = h_inv_host[4], hinv5 = h_inv_host[5];
   Kokkos::parallel_for(
       "matgl_kk:fill_edges",
       Kokkos::RangePolicy<DeviceType>(0, inum),
@@ -235,11 +276,24 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
           const double dz = x(j, 2) - zi;
           const double rsq = dx * dx + dy * dy + dz * dz;
           if (rsq > r_max_sq) continue;
+
+          const int j_local = d_local_row_of(j);
+          // Integer image vector (nx,ny,nz) such that
+          //   x[j] == x[j_local] + (nx,ny,nz) @ cell
+          // (boxlo cancels in the difference -- same affine map as
+          // Domain::x2lamda, applied directly to x[j] - x[j_local]).
+          const double ddx = x(j, 0) - x(j_local, 0);
+          const double ddy = x(j, 1) - x(j_local, 1);
+          const double ddz = x(j, 2) - x(j_local, 2);
+          const double lz = hinv2 * ddz;
+          const double ly = hinv1 * ddy + hinv3 * ddz;
+          const double lx = hinv0 * ddx + hinv5 * ddy + hinv4 * ddz;
+
           d_edge_index_(0, e) = i;
-          d_edge_index_(1, e) = j;
-          d_unit_shifts_(e, 0) = 0;
-          d_unit_shifts_(e, 1) = 0;
-          d_unit_shifts_(e, 2) = 0;
+          d_edge_index_(1, e) = j_local;
+          d_unit_shifts_(e, 0) = static_cast<int64_t>(Kokkos::round(lx));
+          d_unit_shifts_(e, 1) = static_cast<int64_t>(Kokkos::round(ly));
+          d_unit_shifts_(e, 2) = static_cast<int64_t>(Kokkos::round(lz));
           ++e;
         }
       });
@@ -335,15 +389,18 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
       });
 
   // 9) Virial — the model returns a small 3x3 tensor; pull to host.
+  //    The model returns virials = dE/dstrain (strain_grad), but LAMMPS'
+  //    virial[] convention is W = sum_i r_i (x) f_i = -dE/dstrain (matches
+  //    pair_gnnp.cpp: virial -= volume * stress, with ASE stress = dE/dstrain / V).
   if (vflag_global) {
     auto vir_t = out.at("virials").toTensor().to(torch::kFloat64).cpu();
     auto va = vir_t.accessor<double, 2>();
-    virial[0] += va[0][0];
-    virial[1] += va[1][1];
-    virial[2] += va[2][2];
-    virial[3] += 0.5 * (va[0][1] + va[1][0]);
-    virial[4] += 0.5 * (va[0][2] + va[2][0]);
-    virial[5] += 0.5 * (va[1][2] + va[2][1]);
+    virial[0] -= va[0][0];
+    virial[1] -= va[1][1];
+    virial[2] -= va[2][2];
+    virial[3] -= 0.5 * (va[0][1] + va[1][0]);
+    virial[4] -= 0.5 * (va[0][2] + va[2][0]);
+    virial[5] -= 0.5 * (va[1][2] + va[2][1]);
   }
 }
 

--- a/lammps/src/KOKKOS/pair_matgl_kokkos.h
+++ b/lammps/src/KOKKOS/pair_matgl_kokkos.h
@@ -52,10 +52,24 @@ class PairMATGLKokkos : public PairMATGL {
   torch::Device torch_device_ = torch::kCPU;
 
   // Persistent device-side buffers — re-allocated on size change.
-  Kokkos::View<int64_t **, DeviceType> d_edge_index_;        // (2, E)
-  Kokkos::View<int64_t **, DeviceType> d_unit_shifts_;       // (E, 3)
+  // NOTE: explicit LayoutRight is required here. Without it, DeviceType's
+  // default array_layout (LayoutLeft on Cuda, LayoutRight on host) leaves
+  // the on-device memory column-major, while blob_from_view()/from_blob()
+  // below always reinterpret the raw buffer as row-major. On the CUDA
+  // backend that mismatch scrambled edge_index into a bogus graph topology
+  // (wrong energy, zero/NaN forces); the host backend happened to match by
+  // coincidence since its default layout is already LayoutRight.
+  Kokkos::View<int64_t **, Kokkos::LayoutRight, DeviceType> d_edge_index_;        // (2, E)
+  Kokkos::View<int64_t **, Kokkos::LayoutRight, DeviceType> d_unit_shifts_;       // (E, 3)
   Kokkos::View<int64_t *, DeviceType> d_atomic_numbers_;     // (N,)
   Kokkos::View<bool *, DeviceType> d_local_or_ghost_;        // (N,)
+  // local_row_of_(j) = the local (owned, <nlocal) row representing the same
+  // physical atom as row j. Identity for local rows; for ghosts, the owned
+  // copy with the same tag. Built host-side once per compute() (cheap vs.
+  // the model forward pass) and uploaded -- see pair_matgl.cpp for why this
+  // exists (TensorNet needs one consistent row per atom; periodicity goes
+  // through unit_shifts, not through ghost-row duplication).
+  Kokkos::View<int *, DeviceType> d_local_row_of_;           // (N,)
 
   // Edge-counting scratch.
   Kokkos::View<int *, DeviceType> d_numneigh_short_;

--- a/lammps/src/ML-MATGL/export_matgl_checkpoint.py
+++ b/lammps/src/ML-MATGL/export_matgl_checkpoint.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""Export a matgl checkpoint directory to a LAMMPS-ready TorchScript module.
+
+Invoked automatically by pair_matgl/pair_matgl_kokkos's coeff() when
+pair_coeff is given a directory (or a model.pt next to a model.json +
+state.pt) holding a matgl IOMixIn checkpoint (model.json + model.pt +
+state.pt), rather than an already-exported TorchScript module.
+
+Usage: export_matgl_checkpoint.py <checkpoint_dir> <output.pt>
+"""
+
+import sys
+
+import torch
+
+import matgl
+
+# matgl/src/matgl/ext/_lammps.py imports create_line_graph_torch, which is
+# only used by the M3GNet export path and is absent from the current
+# _compute_pyg.py. Irrelevant to TensorNet exports; shim it in-memory only
+# (no matgl repo file changes) so the import below succeeds.
+import matgl.graph._compute_pyg as _cpyg
+
+if not hasattr(_cpyg, "create_line_graph_torch"):
+    _cpyg.create_line_graph_torch = _cpyg.create_line_graph
+
+from matgl.ext._lammps import export_lammps_model
+
+checkpoint_dir, out_path = sys.argv[1], sys.argv[2]
+potential = matgl.load_model(checkpoint_dir)
+export_lammps_model(potential, out_path, dtype=torch.float32, script=True)

--- a/lammps/src/ML-MATGL/pair_matgl.cpp
+++ b/lammps/src/ML-MATGL/pair_matgl.cpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <filesystem>
 
 using namespace LAMMPS_NS;
 
@@ -126,7 +127,54 @@ void PairMATGL::coeff(int narg, char **arg)
   if (std::strcmp(arg[0], "*") != 0 || std::strcmp(arg[1], "*") != 0)
     error->all(FLERR, "pair_coeff matgl requires both type indices to be '*'");
 
-  const std::string model_path = arg[2];
+  std::string model_path = arg[2];
+  {
+    namespace fs = std::filesystem;
+    fs::path p(model_path);
+    fs::path dir = fs::is_directory(p) ? p : p.parent_path();
+    fs::path native_config = dir / "model.json";
+    fs::path native_state = dir / "state.pt";
+
+    if (fs::exists(native_config) && fs::exists(native_state)) {
+      // `dir` holds a matgl IOMixIn checkpoint (model.json + model.pt +
+      // state.pt) rather than a LAMMPS-ready TorchScript module. Export
+      // (and cache) a scripted model alongside it, then load that instead.
+      fs::path cached = dir / "lammps_model.pt";
+
+      bool need_export = !fs::exists(cached);
+      if (!need_export) {
+        auto cached_time = fs::last_write_time(cached);
+        for (const auto &src : {native_config, native_state})
+          if (fs::last_write_time(src) > cached_time) need_export = true;
+      }
+
+      if (need_export) {
+        if (comm->me == 0) {
+          utils::logmesg(lmp,
+                         "pair_matgl: exporting matgl checkpoint '{}' to LAMMPS "
+                         "TorchScript format (one-time, cached as '{}')...\n",
+                         dir.string(), cached.string());
+          static const std::string kPython = "/global/cfs/cdirs/m4845/repos/matgl/.venv/bin/python";
+          static const std::string kExportScript =
+              "/global/cfs/cdirs/m4845/repos/lammps/src/ML-MATGL/export_matgl_checkpoint.py";
+          std::string cmd = kPython + " '" + kExportScript + "' '" + dir.string() + "' '" +
+                             cached.string() + "'";
+          int rc = std::system(cmd.c_str());
+          if (rc != 0)
+            error->one(FLERR, "pair_matgl: export of matgl checkpoint '{}' failed (command '{}' exited {})",
+                       dir.string(), cmd, rc);
+        }
+        MPI_Barrier(world);
+        if (!fs::exists(cached))
+          error->all(FLERR, "pair_matgl: expected exported model '{}' not found after export",
+                     cached.string());
+      }
+
+      model_path = cached.string();
+    } else if (fs::exists(p) && fs::is_directory(p)) {
+      model_path = (p / "model.pt").string();
+    }
+  }
 
   // Try-catch around torch::jit::load: if libtorch can't read the file or the
   // module's forward signature isn't ours, surface a useful error early.
@@ -308,6 +356,26 @@ void PairMATGL::compute(int eflag, int vflag)
   edge_dst.reserve(nall * 32);
   edge_shifts.reserve(nall * 32 * 3);
 
+  // TensorNet's message-passing layers require every physical atom to be
+  // addressed by ONE consistent row index across all its edges; periodicity
+  // must be encoded as a position offset on that same row (unit_shifts @
+  // cell), not as a second "ghost" row. A ghost row only ever appears as an
+  // edge destination here (only owned atoms are loop centers below), so it
+  // never propagates outgoing messages and the real atom never receives the
+  // message that landed on its ghost -- silently dropping every
+  // periodic-boundary bond's contribution. So: resolve every neighbor `j`
+  // back to the local row of the atom it represents via its tag, and
+  // recover the integer image vector from the (cancelling-boxlo) Cartesian
+  // offset between the ghost and its owned copy.
+  if (comm->nprocs > 1)
+    error->all(FLERR,
+               "pair_style matgl: multi-rank (MPI-decomposed) runs are not "
+               "yet supported -- ghost atoms may be owned by a different "
+               "rank, so there is no local row to fold periodic edges back "
+               "onto. Run with a single MPI rank.");
+
+  const double *const h_inv = domain->h_inv;
+
   for (int ii = 0; ii < inum; ++ii) {
     const int i = ilist[ii];
     const double xi = x[i][0];
@@ -324,20 +392,36 @@ void PairMATGL::compute(int eflag, int vflag)
       const double rsq = dx * dx + dy * dy + dz * dz;
       if (rsq > r_max_squared_) continue;
 
-      // unit_shifts: integer image vector (nx,ny,nz) such that
-      //   x[j] == x_owned[j_local] + (nx,ny,nz) @ cell
-      // For LAMMPS' "i and ghost j" pattern we leave shifts at zero and
-      // let the Python wrapper compute pbc_offshift = unit_shifts @ cell;
-      // it always evaluates to zero because LAMMPS hands us already-imaged
-      // ghost positions. The wrapper gradient with respect to the strain
-      // tensor still propagates correctly because the cell appears via
-      //   pos_s = positions @ (I + strain)
-      // applied to BOTH local and ghost positions.
+      // Fold `j` (local or ghost) back onto the local row of the atom it
+      // represents. For a local atom this is `j` itself (shift 0,0,0); for
+      // a ghost it's the owned copy with the same tag.
+      const int j_local = atom->map(atom->tag[j]);
+      if (j_local < 0 || j_local >= nlocal)
+        error->one(FLERR,
+                   "pair_style matgl: could not resolve neighbor atom "
+                   "{} (tag {}) to a local row -- is `atom_modify map yes` "
+                   "set, and is this a single-rank run?",
+                   j, atom->tag[j]);
+
+      // Integer image vector (nx,ny,nz) such that
+      //   x[j] == x[j_local] + (nx,ny,nz) @ cell
+      // boxlo cancels in the difference, so this is the same affine map
+      // Domain::x2lamda uses, applied to (x[j] - x[j_local]) directly.
+      const double ddx = x[j][0] - x[j_local][0];
+      const double ddy = x[j][1] - x[j_local][1];
+      const double ddz = x[j][2] - x[j_local][2];
+      const double lz = h_inv[2] * ddz;
+      const double ly = h_inv[1] * ddy + h_inv[3] * ddz;
+      const double lx = h_inv[0] * ddx + h_inv[5] * ddy + h_inv[4] * ddz;
+      const int64_t nx = static_cast<int64_t>(std::lround(lx));
+      const int64_t ny = static_cast<int64_t>(std::lround(ly));
+      const int64_t nz = static_cast<int64_t>(std::lround(lz));
+
       edge_src.push_back(static_cast<int64_t>(i));
-      edge_dst.push_back(static_cast<int64_t>(j));
-      edge_shifts.push_back(0);
-      edge_shifts.push_back(0);
-      edge_shifts.push_back(0);
+      edge_dst.push_back(static_cast<int64_t>(j_local));
+      edge_shifts.push_back(nx);
+      edge_shifts.push_back(ny);
+      edge_shifts.push_back(nz);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix the `pair_matgl`/`pair_matgl/kk` ghost-row bug: periodic neighbors were folded onto duplicate ghost rows with `unit_shifts` always zero, which silently dropped TensorNet's outgoing messages since the model needs exactly one consistent row per physical atom. Now every edge resolves to its local row via `atom->map()`, with an explicit integer `unit_shifts` recovered from the ghost/local position offset — fixes a ~30-42 eV energy gap against the native matgl/ASE calculator.
- Sync `lammps/src/KOKKOS/pair_matgl_kokkos.{cpp,h}` with the version actually exercised on hardware (this fix + the virial sign fix + a `Kokkos::LayoutRight` fix for `edge_index`/`unit_shifts` views + correct GPU device selection + a multi-rank guard) — previously these only existed in a separately-patched build tree and had drifted from this repo.
- Update the README's "Implementation notes" to describe the actual algorithm instead of the old (buggy) ghost-position description.
- Add a `build_pair_matgl_kokkos` CI job mirroring the existing CPU job, for when a self-hosted CUDA runner is registered against this repo.

## Test plan
- [x] Single-point energy/stress on the 4-atom Mo-S test deck (`lammps/tests/in.matgl_si`) matches the Python reference (`python_reference.py`) to ~2e-6 eV, run via `-k on g 1 -sf kk` on an A100 GPU.
