### PR TITLE
fix: cast numpy int to Python int in compute_line_graph loop

### DIFF
--- a/src/matgl/graph/_compute.py
+++ b/src/matgl/graph/_compute.py
@@ -143,7 +143,8 @@ def _compute_3body_indices(
     triple_bond_indices = np.empty((n_triple, 2), dtype=matgl.int_np)
     start = 0
     cs = 0
-    for n in n_bond_per_atom:
+    for n_np in n_bond_per_atom:
+        n = int(n_np)
         if n > 0:
             r = np.arange(n)
             x, y = np.meshgrid(r, r, indexing="xy")


### PR DESCRIPTION
Resolves mypy assignment errors where start/cs were promoted to numpy signed integers by in-place addition with a numpy loop variable.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
