### PR TITLE
Fix neighbor_list_from_ase(compute_distances=True) crashing on periodic structures

### DIFF
--- a/src/matgl/ext/_alchmtk.py
+++ b/src/matgl/ext/_alchmtk.py
@@ -217,7 +217,11 @@ def _compute_distances(
     """Compute the distances between the source and destination atoms."""
     vectors = positions[dst_id] - positions[src_id]
     if cell is not None and unit_shifts is not None:
-        vectors += unit_shifts @ cell
+        # unit_shifts arrives as an integer tensor from the neighbor-list
+        # kernel; integer x float matmul raises "expected mat1 and mat2 to
+        # have the same dtype", so every periodic call with
+        # compute_distances=True (the default) crashed here.
+        vectors += unit_shifts.to(positions.dtype) @ cell
     return torch.linalg.norm(vectors, dim=1)
 
 

--- a/tests/ext/test_alchmtk_neighborlist.py
+++ b/tests/ext/test_alchmtk_neighborlist.py
@@ -1,0 +1,38 @@
+"""Tests for the ``matgl.ext._alchmtk`` neighbor-list helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("nvalchemiops", reason="nvalchemi-toolkit-ops required")
+
+from ase.build import bulk
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="the nvalchemiops path needs CUDA")
+
+
+def test_neighbor_list_from_ase_computes_distances_on_periodic_cells():
+    """``compute_distances=True`` (the default) must work under PBC.
+
+    ``_compute_distances`` did ``unit_shifts @ cell`` with the integer shift
+    matrix the neighbor-list kernel returns, and integer x float matmul
+    raises ``RuntimeError: expected mat1 and mat2 to have the same dtype``.
+    Non-periodic structures dodge the path (``unit_shifts is None``), which
+    is how it survived smoke tests. Beyond surviving, the values must match
+    a float64 recomputation from the returned tensors.
+    """
+    from matgl.ext._alchmtk import neighbor_list_from_ase
+
+    atoms = bulk("NaCl", "rocksalt", a=5.64).repeat((3, 3, 3))
+    src, dst, dist, shifts, pos, _ = neighbor_list_from_ase(atoms, cutoff=5.0, compute_distances=True, device="cuda")
+
+    assert dist is not None
+    assert dist.shape[0] == src.shape[0]
+    cell = torch.as_tensor(atoms.get_cell().array, dtype=torch.float64, device=pos.device)
+    ref = torch.linalg.norm(
+        pos[dst.long()].double() + shifts.double() @ cell - pos[src.long()].double(),
+        dim=1,
+    )
+    assert torch.allclose(dist.double(), ref, atol=1e-4)
+    assert float(dist.max()) <= 5.0 + 1e-4


### PR DESCRIPTION
## Summary

`matgl.ext._alchmtk._compute_distances` does

```python
vectors += unit_shifts @ cell
```

with the `unit_shifts` tensor exactly as the nvalchemiops neighbor-list
kernel returns it — an **integer** tensor. Integer × float `matmul` is not
defined in PyTorch, so the call raises

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: int != float
```

Because `compute_distances=True` is the **default** of
`neighbor_list_from_ase`, the default call crashes on **any** structure
with periodic boundary conditions. `neighbor_list_from_structure` shares
the same sink and is hit even harder: a pymatgen `Structure` is always
periodic, so its default call crashes on **every** input. Non-periodic
inputs dodge the path (`unit_shifts is None`), which is how it survived
smoke tests — and notably, all three internal callers in
`matgl.ext.pymatgen` / `matgl.ext.ase` explicitly pass
`compute_distances=False`, so the default path had zero coverage anywhere.
The one-line fix at `_compute_distances` repairs all three public entry
points at once.

## Who hits this — and who doesn't

Nothing in matgl's own pipelines calls this branch today: model
training/inference and MD go through `Structure2Graph`, which computes bond
distances elsewhere. Existing results are unaffected, which is also why the
crash went unnoticed. It bites the first *direct* user of the public API on a
periodic system, e.g.:

- downstream code that reaches for matgl's GPU neighbor list as a building
  block (an MD engine, an adapter, a new-model prototype) — the natural call
  `neighbor_list_from_ase(atoms, cutoff)` crashes on any crystal (this is how
  we found it, while auditing neighbor lists);
- structure-analysis tooling (coordination numbers, RDF prep, bond
  statistics) — exactly the use case the returned `distances` exist for, and
  almost always on periodic cells;
- cross-implementation validation, comparing another neighbor-list build
  against matgl's;
- any future matgl-internal refactor that starts using this utility with
  distances — fixing it now removes that landmine before it can reach the
  main pipeline.

## Fix

One line — cast the shifts to the position dtype at the point of use:

```python
vectors += unit_shifts.to(positions.dtype) @ cell
```

## Test

`tests/ext/test_alchmtk_neighborlist.py`: a periodic rocksalt supercell through the
default `compute_distances=True` path. It asserts not only that the call
survives but that the returned distances match a float64 recomputation
from the returned `(positions, shifts, cell)` to 1e-4 and respect the
cutoff.

Verified on H200 / CUDA 12.4 / matgl 4.0.3: the test **fails before** the
patch with the RuntimeError above and **passes after** it.

## While auditing this path

We also cross-checked the neighbor *list* itself (not part of this PR,
reported for confidence): on a dense triclinic 1,248-atom cell at 5.0 Å,
`neighbor_list_from_ase` returned an edge set **bit-identical** (shift
vectors included) to an exact O(N²) minimum-image reference — 25,242
edges, zero missing, zero spurious. The `_safe_nl` retry-on-overflow logic
works as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


