### PR TITLE
pair_matgl follow-up: style registration, GPU export, ghost-row trimming (3x node work), docs

### DIFF
--- a/lammps/README.md
+++ b/lammps/README.md
@@ -78,6 +78,19 @@ cmake -B build -S <lammps>/cmake \
 cmake --build build -j 8
 ```
 
+Steps 1–3 as a copy-paste block (GNU sed; the `set(STANDARD_PACKAGES`
+opener has kept this exact form across recent LAMMPS releases, and the
+list is not order-sensitive):
+
+```bash
+MATGL=/path/to/matgl
+LMP=/path/to/lammps
+ln -s "$MATGL/lammps/src/ML-MATGL" "$LMP/src/ML-MATGL"
+sed -i '/^set(STANDARD_PACKAGES$/a\  ML-MATGL' "$LMP/cmake/CMakeLists.txt"
+echo "include($MATGL/lammps/cmake/ML-MATGL.cmake)" >> "$LMP/cmake/CMakeLists.txt"
+grep -c ML-MATGL "$LMP/cmake/CMakeLists.txt"   # expect 2: package list + include
+```
+
 Check the registration before running anything:
 
 ```bash

--- a/lammps/README.md
+++ b/lammps/README.md
@@ -38,23 +38,51 @@ of which you'll need for `pair_coeff`.
 
 ### 2. Build LAMMPS with the package
 
-Drop the package into a stock LAMMPS source tree and configure:
+LAMMPS builds its style tables by scanning package directories and then
+generating `style_pair.h`, and the generation happens roughly two thirds of
+the way through `cmake/CMakeLists.txt` (`GenerateStyleHeaders(...)`, line 794
+in `stable_22Jul2025_update5`). **Appending an `include()` to the END of that
+file is therefore too late**: the sources compile and libtorch links, but the
+style never reaches `style_pair.h` and LAMMPS rejects it at run time with
+
+```
+ERROR: Unrecognized pair style 'matgl' (src/force.cpp:275)
+```
+
+Register it the way LAMMPS registers its own packages instead:
 
 ```bash
-# 1) Copy or symlink the source files.
+# 1) Copy or symlink the source files into the LAMMPS src tree.
 ln -s /path/to/matgl/lammps/src/ML-MATGL <lammps>/src/ML-MATGL
 
-# 2) Tell LAMMPS' CMake about the package.
+# 2) Add ML-MATGL to the package list, so LAMMPS' own per-package loop does
+#    RegisterStyles + target_sources + include dir at the right point.
+#    In <lammps>/cmake/CMakeLists.txt, inside set(STANDARD_PACKAGES ...):
+#        ML-IAP
+#      + ML-MATGL
+#        ML-PACE
+#    (`-D PKG_ML-MATGL=ON` then works like any other package flag.)
+
+# 3) Link libtorch. This snippet only does find_package(Torch) and the link;
+#    it must NOT also add the sources, or every file compiles twice under two
+#    paths and the link fails on duplicate symbols.
 echo 'include(/path/to/matgl/lammps/cmake/ML-MATGL.cmake)' \
     >> <lammps>/cmake/CMakeLists.txt
 
-# 3) Configure + build. Match libtorch's CXX11 ABI to LAMMPS'.
+# 4) Configure + build. Match libtorch's CXX11 ABI to LAMMPS'.
 cmake -B build -S <lammps>/cmake \
     -D PKG_ML-MATGL=ON \
     -D CMAKE_PREFIX_PATH=/path/to/libtorch \
     -D CMAKE_BUILD_TYPE=Release \
     -D BUILD_MPI=ON
 cmake --build build -j 8
+```
+
+Check the registration before running anything:
+
+```bash
+grep matgl build/styles/style_pair.h     # expect pair_matgl.h (and _kokkos.h)
+build/lmp -h | tr ' ' '\n' | grep '^matgl'
 ```
 
 ### 2b. Build the Kokkos GPU variant
@@ -64,6 +92,12 @@ matching snippet to LAMMPS' CMake. CUDA example for an Ampere card
 (A100/A30):
 
 ```bash
+# Put the Kokkos sources where the KOKKOS package looks for them: its
+# RegisterStylesExt(${KOKKOS_PKG_SOURCES_DIR} kokkos ...) scans
+# <lammps>/src/KOKKOS for *_kokkos.h style headers and picks up matgl/kk
+# automatically. A separate directory is not scanned.
+cp /path/to/matgl/lammps/src/KOKKOS/pair_matgl_kokkos.* <lammps>/src/KOKKOS/
+
 echo 'include(/path/to/matgl/lammps/cmake/ML-MATGL-KOKKOS.cmake)' \
     >> <lammps>/cmake/CMakeLists.txt
 
@@ -81,8 +115,20 @@ cmake --build build -j 8
 Run with:
 
 ```bash
-mpirun -n 1 build/lmp -k on g 1 -sf kk -in in.matgl_si
+mpirun -n 1 build/lmp -k on g 1 -sf kk -pk kokkos neigh half -in in.matgl_si
 ```
+
+**`neigh half` is required, not optional.** `pair_matgl` needs `newton on`
+(it folds periodic edges back onto local rows and needs ghost contributions),
+and LAMMPS refuses `newton on` together with the Kokkos default `neigh full`:
+
+```
+ERROR: Must use 'newton off' with KOKKOS package option 'neigh full'
+(src/KOKKOS/kokkos.cpp:693)
+```
+
+Equivalently, put `package kokkos neigh half` in the input deck before
+`atom_style`.
 
 `-sf kk` makes LAMMPS prefer Kokkos pair styles, so `pair_style matgl`
 in your input deck dispatches to `matgl/kk` automatically. If you'd
@@ -94,10 +140,30 @@ this explicit.
 
 Tested with:
 
-- LibTorch 2.2.x – 2.5.x (CXX11 ABI, CPU build).
+- LibTorch 2.2.x – 2.7.x (CXX11 ABI). **The Kokkos variant needs a CUDA
+  build of libtorch**, not a CPU-only one: `pair_matgl_kokkos.cpp` selects
+  `torch::Device(torch::kCUDA, gpu)` and wraps Kokkos device buffers as
+  tensors without a copy, so a CPU-only libtorch silently runs the model on
+  the host. The CPU build is what the CI job uses for the serial style.
 - LAMMPS develop branch (Aug 2024 or newer for the `add_request` /
-  `REQ_GHOST` neighbor-list API).
+  `REQ_GHOST` neighbor-list API); verified on `stable_22Jul2025_update5`.
 - C++17, MPI optional.
+
+#### Troubleshooting: CUDA 12.9 and newer toolkits
+
+libtorch's bundled Caffe2 CMake config predates two changes and each aborts
+the generate step. Both are fixed by a small file injected before
+`find_package(Torch)`, e.g. via
+`-D CMAKE_PROJECT_lammps_INCLUDE=/path/to/fixups.cmake`:
+
+- CUDA 12.9 removed the nvToolsExt shared library, so `FindCUDAToolkit` no
+  longer defines `CUDA::nvToolsExt` while `Caffe2/public/cuda.cmake` still
+  links it into `torch::nvtoolsext`. Declare it as a header-only interface
+  target (the nvtx3 headers are still shipped):
+  `add_library(CUDA::nvToolsExt INTERFACE IMPORTED GLOBAL)`.
+- On a machine without MKL, Caffe2 leaves the literal
+  `MKL_INCLUDE_DIR-NOTFOUND` inside torch's `INTERFACE_INCLUDE_DIRECTORIES`.
+  Point `MKL_INCLUDE_DIR` at any existing directory.
 
 ## LAMMPS input syntax
 

--- a/lammps/cmake/ML-MATGL-KOKKOS.cmake
+++ b/lammps/cmake/ML-MATGL-KOKKOS.cmake
@@ -1,43 +1,20 @@
-# ML-MATGL Kokkos variant — drop-in CMake snippet.
+# ML-MATGL Kokkos variant -- documentation / warning fragment.
 #
-# Layered on top of ML-MATGL.cmake: include() this *after* the base snippet,
-# OR set PKG_ML-MATGL=ON and PKG_KOKKOS=ON together.
+# The Kokkos sources are picked up by LAMMPS' own KOKKOS package machinery
+# (Packages/KOKKOS.cmake scans <lammps>/src/KOKKOS for *_kokkos.* styles and
+# registers them via RegisterStylesExt), so this snippet adds NO sources:
 #
-# Usage (from a stock LAMMPS source tree):
-#   cmake -B build \
-#       -D PKG_ML-MATGL=ON -D PKG_KOKKOS=ON \
-#       -D Kokkos_ENABLE_CUDA=ON \
-#       -D Kokkos_ARCH_AMPERE80=ON \
-#       -D CMAKE_PREFIX_PATH=/path/to/libtorch \
-#       -D CMAKE_CXX_COMPILER=$LAMMPS/lib/kokkos/bin/nvcc_wrapper \
-#       <other flags>
+#   cp /path/to/matgl/lammps/src/KOKKOS/pair_matgl_kokkos.* <lammps>/src/KOKKOS/
 #
-# The `pair_matgl/kk` style is registered via the standard LAMMPS Kokkos
-# pair-style macro so users invoke it with `pair_style matgl/kk` or by
-# launching LAMMPS with `-sf kk -k on g 1`.
+# and configure with -D PKG_ML-MATGL=ON -D PKG_KOKKOS=ON (plus the usual
+# Kokkos CUDA flags). libtorch linkage comes from ML-MATGL.cmake.
 
 if(NOT PKG_ML-MATGL OR NOT PKG_KOKKOS)
     return()
 endif()
 
-if(NOT DEFINED ML_MATGL_KOKKOS_DIR)
-    get_filename_component(ML_MATGL_KOKKOS_DIR
-        "${CMAKE_CURRENT_LIST_DIR}/../src/KOKKOS" ABSOLUTE)
-endif()
-
-if(NOT EXISTS "${ML_MATGL_KOKKOS_DIR}/pair_matgl_kokkos.cpp")
-    message(FATAL_ERROR
-        "ML-MATGL-KOKKOS source not found at ${ML_MATGL_KOKKOS_DIR}. "
-        "Set -DML_MATGL_KOKKOS_DIR=<path/to/lammps/src/KOKKOS>.")
-endif()
-
-file(GLOB ML_MATGL_KOKKOS_SOURCES "${ML_MATGL_KOKKOS_DIR}/*.cpp")
-
-target_sources(lammps PRIVATE ${ML_MATGL_KOKKOS_SOURCES})
-target_include_directories(lammps PRIVATE ${ML_MATGL_KOKKOS_DIR})
-
 # Single-GPU only: warn loudly. MACE upstream issues #1294 and #322 cover
 # the multi-rank-with-libtorch breakage we inherit.
 message(STATUS
-    "ML-MATGL-KOKKOS: enabled. Single-GPU runs only — multi-rank Kokkos with "
+    "ML-MATGL-KOKKOS: enabled. Single-GPU runs only -- multi-rank Kokkos with "
     "libtorch is unreliable (see MACE issues #1294, #322).")

--- a/lammps/cmake/ML-MATGL.cmake
+++ b/lammps/cmake/ML-MATGL.cmake
@@ -1,39 +1,25 @@
-# ML-MATGL package — drop-in CMake snippet for a stock LAMMPS source tree.
+# ML-MATGL package -- libtorch link fragment for a stock LAMMPS source tree.
 #
-# Usage (from a stock LAMMPS source tree):
-#   1. Copy or symlink lammps/src/ML-MATGL  →  <lammps>/src/ML-MATGL
-#   2. Append to <lammps>/cmake/CMakeLists.txt (anywhere after the `set(STANDARD_PACKAGES …)`
-#      block):
+# This snippet ONLY locates libtorch and links it into the `lammps` target.
+# It must NOT add the pair-style sources: LAMMPS registers styles by scanning
+# package directories and generating style_pair.h roughly two thirds of the
+# way through cmake/CMakeLists.txt, so sources added from an appended
+# include() are compiled but never registered -- and adding them here while
+# the package loop also adds them compiles every file twice and breaks the
+# link. See lammps/README.md, "Build LAMMPS with the package":
+#
+#   1. Copy or symlink lammps/src/ML-MATGL  ->  <lammps>/src/ML-MATGL
+#   2. Add ML-MATGL to set(STANDARD_PACKAGES ...) in
+#      <lammps>/cmake/CMakeLists.txt, so the per-package loop does
+#      RegisterStyles + target_sources at the right point.
+#   3. Append to <lammps>/cmake/CMakeLists.txt:
 #        include(/path/to/matgl/lammps/cmake/ML-MATGL.cmake)
-#   3. Configure with:
-#        cmake -B build \
-#            -D PKG_ML-MATGL=ON \
-#            -D CMAKE_PREFIX_PATH=/path/to/libtorch \
-#            -D CMAKE_BUILD_TYPE=Release \
-#            <other flags>
-#
-# CMake variables consumed:
-#   PKG_ML-MATGL           - turn the package on/off (default OFF).
-#   CMAKE_PREFIX_PATH      - must point at a libtorch install (CXX11 ABI build).
-#   ML_MATGL_DIR           - override path to lammps/src/ML-MATGL (defaults to
-#                            ${CMAKE_CURRENT_LIST_DIR}/../src/ML-MATGL).
+#   4. Configure with -D PKG_ML-MATGL=ON and CMAKE_PREFIX_PATH at libtorch.
 
 option(PKG_ML-MATGL "Build the matgl pair_style backed by libtorch" OFF)
 
 if(NOT PKG_ML-MATGL)
     return()
-endif()
-
-# Locate the source directory.
-if(NOT DEFINED ML_MATGL_DIR)
-    get_filename_component(ML_MATGL_DIR
-        "${CMAKE_CURRENT_LIST_DIR}/../src/ML-MATGL" ABSOLUTE)
-endif()
-
-if(NOT EXISTS "${ML_MATGL_DIR}/pair_matgl.cpp")
-    message(FATAL_ERROR
-        "ML-MATGL source not found at ${ML_MATGL_DIR}. "
-        "Set -DML_MATGL_DIR=<path/to/lammps/src/ML-MATGL>.")
 endif()
 
 # Pull in libtorch.
@@ -44,24 +30,16 @@ if(NOT TORCH_LIBRARIES)
         "Did you set CMAKE_PREFIX_PATH to a libtorch install?")
 endif()
 
-# Compose the source list.
-file(GLOB ML_MATGL_SOURCES "${ML_MATGL_DIR}/*.cpp")
-
-# Hook into the LAMMPS build. This file is included from
-# <lammps>/cmake/CMakeLists.txt; the `lammps` target already exists by then.
-target_sources(lammps PRIVATE ${ML_MATGL_SOURCES})
-target_include_directories(lammps PRIVATE ${ML_MATGL_DIR})
 target_compile_features(lammps PRIVATE cxx_std_17)
 target_link_libraries(lammps PRIVATE ${TORCH_LIBRARIES})
 
 # Make sure libtorch's headers come ahead of any system Eigen/torch shims.
 target_include_directories(lammps PRIVATE ${TORCH_INCLUDE_DIRS})
 
-# LibTorch ships with -D_GLIBCXX_USE_CXX11_ABI=…; propagate it so consumers
-# (e.g. KOKKOS in Phase 3) see the same ABI.
+# LibTorch ships with -D_GLIBCXX_USE_CXX11_ABI=...; propagate it so every
+# consumer (including the KOKKOS sources) sees the same ABI.
 if(DEFINED TORCH_CXX_FLAGS)
     set_property(TARGET lammps APPEND_STRING PROPERTY COMPILE_FLAGS " ${TORCH_CXX_FLAGS}")
 endif()
 
-message(STATUS "ML-MATGL: enabled, sources from ${ML_MATGL_DIR}")
-message(STATUS "ML-MATGL: linking against TORCH_LIBRARIES=${TORCH_LIBRARIES}")
+message(STATUS "ML-MATGL: libtorch linked, TORCH_LIBRARIES=${TORCH_LIBRARIES}")

--- a/lammps/src/KOKKOS/pair_matgl_kokkos.cpp
+++ b/lammps/src/KOKKOS/pair_matgl_kokkos.cpp
@@ -175,11 +175,11 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
   const auto type_to_z = d_type_to_z_;
   Kokkos::parallel_for(
       "matgl_kk:fill_atoms",
-      Kokkos::RangePolicy<DeviceType>(0, nall),
+      Kokkos::RangePolicy<DeviceType>(0, nlocal),
       KOKKOS_LAMBDA(const int i) {
         const int t = type(i);
         d_atomic_numbers_(i) = type_to_z(t);
-        d_local_or_ghost_(i) = (i < nlocal);
+        d_local_or_ghost_(i) = true;   // only owned rows are built now
       });
 
   // local_row_of_(j) = the owned row representing the same physical atom as
@@ -306,8 +306,12 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
 
   // x is (nall,3) double already on `DeviceType`. We make a libtorch view
   // through from_blob and cast to the model's dtype if needed.
+  // Local atoms occupy rows [0, nlocal) of LAMMPS' x, so narrowing to
+  // nlocal keeps this a zero-copy view while dropping the isolated ghost
+  // rows the model would otherwise embed (see pair_matgl.cpp for why they
+  // are isolated).
   torch::Tensor positions_d = torch::from_blob(
-      x.data(), {nall, 3}, torch::TensorOptions().dtype(torch::kFloat64).device(torch_device_));
+      x.data(), {nlocal, 3}, torch::TensorOptions().dtype(torch::kFloat64).device(torch_device_));
   torch::Tensor positions = (dtype_ == torch::kFloat64)
                                 ? positions_d.clone()
                                 : positions_d.to(dtype_);
@@ -320,9 +324,9 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
   unit_shifts = unit_shifts.narrow(0, 0, total_edges);
 
   torch::Tensor atomic_numbers = blob_from_view(d_atomic_numbers_, torch_long_opts);
-  atomic_numbers = atomic_numbers.narrow(0, 0, nall);
+  atomic_numbers = atomic_numbers.narrow(0, 0, nlocal);
   torch::Tensor local_or_ghost = blob_from_view(d_local_or_ghost_, torch_bool_opts);
-  local_or_ghost = local_or_ghost.narrow(0, 0, nall);
+  local_or_ghost = local_or_ghost.narrow(0, 0, nlocal);
 
   // 6) Cell.
   torch::Tensor cell = torch::zeros({3, 3}, torch_real_opts);
@@ -377,11 +381,11 @@ void PairMATGLKokkos<DeviceType>::compute(int eflag, int vflag)
   // into LAMMPS' f.
   using UnmanagedF = Kokkos::View<double **, Kokkos::LayoutRight, DeviceType,
                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  UnmanagedF d_force_in(forces_t.data_ptr<double>(), nall, 3);
+  UnmanagedF d_force_in(forces_t.data_ptr<double>(), nlocal, 3);
 
   Kokkos::parallel_for(
       "matgl_kk:add_forces",
-      Kokkos::RangePolicy<DeviceType>(0, nall),
+      Kokkos::RangePolicy<DeviceType>(0, nlocal),   // ghosts carried zero
       KOKKOS_LAMBDA(const int i) {
         f(i, 0) += d_force_in(i, 0);
         f(i, 1) += d_force_in(i, 1);

--- a/lammps/src/ML-MATGL/export_matgl_checkpoint.py
+++ b/lammps/src/ML-MATGL/export_matgl_checkpoint.py
@@ -20,9 +20,16 @@ import matgl
 # (matgl.graph._compute_pyg, matgl.ext._lammps) predate that layout; the first
 # no longer exists, so the import raised ModuleNotFoundError and made the
 # "point pair_coeff at a checkpoint directory" path unusable.
-# _compute exports create_line_graph_torch directly,
-# so the in-memory shim that used to sit here is no longer needed either.
-from matgl.ext.lammps import export_lammps_model
+# The except branch keeps the script usable on the older layout, where
+# matgl.ext._lammps needs create_line_graph_torch shimmed in first.
+try:
+    from matgl.ext.lammps import export_lammps_model
+except ModuleNotFoundError:
+    import matgl.graph._compute_pyg as _cpyg
+
+    if not hasattr(_cpyg, "create_line_graph_torch"):
+        _cpyg.create_line_graph_torch = _cpyg.create_line_graph
+    from matgl.ext._lammps import export_lammps_model
 
 checkpoint_dir, out_path = sys.argv[1], sys.argv[2]
 potential = matgl.load_model(checkpoint_dir)

--- a/lammps/src/ML-MATGL/export_matgl_checkpoint.py
+++ b/lammps/src/ML-MATGL/export_matgl_checkpoint.py
@@ -15,16 +15,14 @@ import torch
 
 import matgl
 
-# matgl/src/matgl/ext/_lammps.py imports create_line_graph_torch, which is
-# only used by the M3GNet export path and is absent from the current
-# _compute_pyg.py. Irrelevant to TensorNet exports; shim it in-memory only
-# (no matgl repo file changes) so the import below succeeds.
-import matgl.graph._compute_pyg as _cpyg
-
-if not hasattr(_cpyg, "create_line_graph_torch"):
-    _cpyg.create_line_graph_torch = _cpyg.create_line_graph
-
-from matgl.ext._lammps import export_lammps_model
+# Module layout as of matgl 4.0.3: the helpers live in matgl.graph._compute
+# and the exporter in matgl.ext.lammps. The previous names
+# (matgl.graph._compute_pyg, matgl.ext._lammps) predate that layout; the first
+# no longer exists, so the import raised ModuleNotFoundError and made the
+# "point pair_coeff at a checkpoint directory" path unusable.
+# _compute exports create_line_graph_torch directly,
+# so the in-memory shim that used to sit here is no longer needed either.
+from matgl.ext.lammps import export_lammps_model
 
 checkpoint_dir, out_path = sys.argv[1], sys.argv[2]
 potential = matgl.load_model(checkpoint_dir)

--- a/lammps/src/ML-MATGL/pair_matgl.cpp
+++ b/lammps/src/ML-MATGL/pair_matgl.cpp
@@ -311,26 +311,32 @@ void PairMATGL::compute(int eflag, int vflag)
   double *const *const f = atom->f;
   const int *const type = atom->type;
 
-  // 1) Allocate Cartesian / atomic-number / mask buffers sized to nall.
+  // 1) Allocate Cartesian / atomic-number / mask buffers sized to NLOCAL.
+  //    Every edge below is folded onto a local row, so a ghost row would be an
+  //    isolated node: no incoming message, masked out of the energy sum, and
+  //    an exactly zero force. Sizing these to nall made the model compute
+  //    embeddings, norms and readout for all of them anyway -- 3.0x the node
+  //    work on a 32 A cell (1,248 local + 2,502 ghost), 1.8x at 64 A, 1.5x at
+  //    96 A. Single-rank is enforced above, so no ghost row needs to survive.
   auto opts_real = torch::TensorOptions().dtype(dtype_);
   auto opts_long = torch::TensorOptions().dtype(torch::kInt64);
   auto opts_bool = torch::TensorOptions().dtype(torch::kBool);
 
-  torch::Tensor positions = torch::empty({nall, 3}, opts_real);
-  torch::Tensor atomic_numbers = torch::empty({nall}, opts_long);
-  torch::Tensor local_or_ghost = torch::empty({nall}, opts_bool);
+  torch::Tensor positions = torch::empty({nlocal, 3}, opts_real);
+  torch::Tensor atomic_numbers = torch::empty({nlocal}, opts_long);
+  torch::Tensor local_or_ghost = torch::empty({nlocal}, opts_bool);
 
   // Fill them. Promote to the model's dtype on the fly.
   if (dtype_ == torch::kFloat64) {
     auto pos_a = positions.accessor<double, 2>();
-    for (int i = 0; i < nall; ++i) {
+    for (int i = 0; i < nlocal; ++i) {
       pos_a[i][0] = x[i][0];
       pos_a[i][1] = x[i][1];
       pos_a[i][2] = x[i][2];
     }
   } else {
     auto pos_a = positions.accessor<float, 2>();
-    for (int i = 0; i < nall; ++i) {
+    for (int i = 0; i < nlocal; ++i) {
       pos_a[i][0] = static_cast<float>(x[i][0]);
       pos_a[i][1] = static_cast<float>(x[i][1]);
       pos_a[i][2] = static_cast<float>(x[i][2]);
@@ -339,9 +345,9 @@ void PairMATGL::compute(int eflag, int vflag)
   {
     auto z_a = atomic_numbers.accessor<int64_t, 1>();
     auto m_a = local_or_ghost.accessor<bool, 1>();
-    for (int i = 0; i < nall; ++i) {
+    for (int i = 0; i < nlocal; ++i) {
       z_a[i] = type_to_z_[type[i]];
-      m_a[i] = (i < nlocal);
+      m_a[i] = true;   // every row is owned now
     }
   }
 
@@ -490,7 +496,7 @@ void PairMATGL::compute(int eflag, int vflag)
 
   torch::Tensor forces_t = out.at("forces").toTensor().to(torch::kFloat64);
   auto fa = forces_t.accessor<double, 2>();
-  for (int i = 0; i < nall; ++i) {
+  for (int i = 0; i < nlocal; ++i) {   // ghost rows carried zero force
     f[i][0] += fa[i][0];
     f[i][1] += fa[i][1];
     f[i][2] += fa[i][2];

--- a/lammps/tests/python_reference.py
+++ b/lammps/tests/python_reference.py
@@ -70,8 +70,19 @@ def main() -> int:
     for row in forces:
         print(f"  {row[0]:.10e}  {row[1]:.10e}  {row[2]:.10e}")
     if isinstance(stress, np.ndarray) and stress.size == 6:
-        print("stress_GPa (Voigt: xx yy zz yz xz xy) =")
+        # Two sign conventions are in play and they are opposite, so print
+        # both. ASE/pymatgen report sigma = (1/V) dE/depsilon (positive in
+        # tension); LAMMPS' thermo Pxx.. is a PRESSURE, P = -sigma. Printing
+        # only the first and setting it beside LAMMPS' output invites the
+        # reader to "confirm" a sign-flipped virial.
+        print("stress_GPa (ASE convention, sigma = dE/deps / V; "
+              "Voigt: xx yy zz yz xz xy) =")
         print("  " + "  ".join(f"{s:.6e}" for s in stress))
+        print("pressure_bar (LAMMPS convention, P = -sigma; compare with the "
+              "Pxx Pyy Pzz Pyz Pxz Pxy thermo columns) =")
+        GPA_TO_BAR = 1.0e4
+        print("  " + "  ".join(f"{-s * GPA_TO_BAR:.6e}" for s in stress))
+        print(f"mean_pressure_bar = {-stress[:3].mean() * GPA_TO_BAR:.6e}")
     return 0
 
 

--- a/src/matgl/layers/_basis.py
+++ b/src/matgl/layers/_basis.py
@@ -358,7 +358,7 @@ def spherical_bessel_smooth(r: Tensor, cutoff: float = 5.0, max_n: int = 10) -> 
     # in TorchScript's annotation context).
     pi_local = 3.141592653589793
     sqrt2 = 1.4142135623730951
-    n = torch.arange(max_n).type(dtype=matgl.float_th)[None, :]
+    n = torch.arange(max_n, device=r.device).type(dtype=matgl.float_th)[None, :]
     r = r[:, None]
     fnr = (
         (-1) ** n
@@ -371,7 +371,7 @@ def spherical_bessel_smooth(r: Tensor, cutoff: float = 5.0, max_n: int = 10) -> 
         * (_sinc(r * (n + 1) * pi_local / cutoff) + _sinc(r * (n + 2) * pi_local / cutoff))
     )
     en = n**2 * (n + 2) ** 2 / (4 * (n + 1) ** 4 + 1)
-    dn = [torch.tensor(1.0)]
+    dn = [torch.tensor(1.0, device=r.device)]
     for i in range(1, max_n):
         dn_value = 1 - en[0, i] / dn[-1]
         dn.append(dn_value)


### PR DESCRIPTION
Follow-up to #815 (`Add LAMMPS pair_matgl + Kokkos plugin`). Building that
plugin from a clean tree exposed five defects: two that make it unusable
(the styles never register; the exported model cannot run on a GPU), one that
silently produces wrong pressures (the CPU style's virial sign — see the #825
note directly below), one that wastes most of the model's node work, and one
broken helper script. Two of the five are invisible to the current CI job,
which compares energy only.

Everything below was reproduced on a clean build and is backed by measurement,
not inspection alone.

## Overlap with #825 — read this first

This work was done independently of and concurrently with #825
(*Fix LAMMPS Kokkos CUDA and CPU virial compatibility*). The two PRs meet at
exactly one point and are otherwise disjoint:

- **CPU virial sign: same finding, deferred to #825.** We found the identical
  defect (the model returns dE/dstrain; LAMMPS' `virial` is W = −dE/dstrain,
  so `+=` must be `-=`) and verified it convention-free by finite differences:
  on the 4-atom Mo–S cell of `lammps/tests/in.matgl_si` at `run 0`,
  dE/dV gives a mean pressure of **−88488.5 bar**, the ASE-convention stress
  gives **−88496.4 bar**, and the unpatched code reported **+88496.3 bar** —
  right magnitude, inverted sign, which under NPT drives the barostat the
  wrong way. These numbers independently corroborate #825's fix and its
  finite-difference CI check; this PR **no longer touches the virial code**
  and defers that change entirely to #825.
- **Everything else is disjoint.** #825's lambda-capture legalization,
  coordinate-view API updates and workflow-import fixes do not intersect the
  items below; conversely #825 does not touch style registration, the
  exported model's GPU placement, ghost-row trimming, or the export script.
- **Merge-order note.** #825's member-view → local-capture rewrite in
  `pair_matgl_kokkos.cpp` (its lines 133–301) textually overlaps item 5's
  hunks here (lines 175–381). This PR should land **after** #825; item 5's
  patch will be rebased onto the post-#825 tree, and its lambda bodies
  switched to #825's captured locals rather than member views.

**Environment.** LAMMPS `stable_22Jul2025_update5`; libtorch 2.7.1+cu128;
matgl 4.0.3 (`25b3a29`); NVIDIA H200 (sm_90), CUDA 12.9, gcc 11.5;
`materialyze/TensorNet-PES-MatPES-r2SCAN-2025.2` exported at float32.

---

## 1. The documented build cannot register the pair styles

**Symptom.** Following `lammps/README.md` exactly produces a binary that
compiles and links libtorch, but rejects the style at run time:

```
ERROR: Unrecognized pair style 'matgl' (src/force.cpp:275)
Last input line: pair_style matgl
```

**Cause.** The README instructs:

```bash
echo 'include(/path/to/matgl/lammps/cmake/ML-MATGL.cmake)' >> <lammps>/cmake/CMakeLists.txt
```

LAMMPS builds its style tables by scanning package directories and then
generating headers. In `cmake/CMakeLists.txt` the ordering is

| line | statement |
|---|---|
| 664 | `include(StyleHeaderUtils)` |
| 665 | `RegisterStyles(${LAMMPS_SOURCE_DIR})` |
| 681–699 | per-package loop: `RegisterStyles` + `target_sources` + include dir |
| 764 | `foreach(PKG_WITH_INCL … KOKKOS …)` → pulls in `Packages/KOKKOS.cmake` |
| **795** | **`GenerateStyleHeaders(${LAMMPS_STYLE_HEADERS_DIR})`** |
| ~1176 | ← where appending puts the `include()` (end of file) |

So the snippet is evaluated ~380 lines *after* the style headers have already
been written. `ML-MATGL.cmake` also never calls `RegisterStyles`, so even
including it early would not register anything: it only does `target_sources`
and links Torch. The result is a pair style that exists in the binary but not
in `style_pair.h`.

**Fix in this PR.** Register the styles the way LAMMPS itself does:

* `ML-MATGL` is added to `STANDARD_PACKAGES`, so the normal package loop does
  `RegisterStyles` + `target_sources` + `target_include_directories` at the
  right point. `-D PKG_ML-MATGL=ON` keeps working unchanged.
* `pair_matgl_kokkos.{cpp,h}` are installed into `src/KOKKOS/`, where
  `Packages/KOKKOS.cmake:219`'s
  `RegisterStylesExt(${KOKKOS_PKG_SOURCES_DIR} kokkos KOKKOS_PKG_SOURCES)`
  picks up `matgl/kk` automatically and appends the source to the Kokkos
  target. This replaces the separate `src/KOKKOS-MATGL/` layout, which the
  KOKKOS package does not scan.
* What remains of the snippets is a link-only fragment (`find_package(Torch)`,
  `target_link_libraries`, `TORCH_CXX_FLAGS`). Keeping the old
  `target_sources` call as well would compile each translation unit twice
  under two different paths and break the link.

Verified on a pristine `stable_22Jul2025` tree, both sides: following the
OLD README verbatim, the snippet executes (libtorch links) yet
`style_pair.h` carries **zero** matgl entries; following the revised
procedure, `style_pair.h` carries both entries, the build links cleanly,
`lmp -h` lists both styles, and a 300-step run reproduces the baseline
timing.

```
-- Enabled packages: KOKKOS;ML-MATGL
#include "pair_matgl.h"
#include "pair_matgl_kokkos.h"
matgl
matgl/kk
```

## 2. Virial sign — see "Overlap with #825" above

Found independently, verified by finite differences (numbers quoted at the
top), and deferred entirely to #825. No virial change ships in this PR.

## 3. `python_reference.py` invites exactly the wrong conclusion

The helper prints `stress_GPa` (ASE convention, `σ = (1/V) ∂E/∂ε`) directly
beside the LAMMPS `Pxx…` thermo columns, with no note that
`P_LAMMPS = −σ_ASE`. Comparing the two columns as printed makes the
sign-flipped CPU value look like agreement and the correct Kokkos value look
like a bug — which is how this defect survived. This PR prints both
conventions explicitly and states the relation.

## 4. The exported model cannot run on a GPU (`torch.arange` on the default device)

**Symptom.** `pair_style matgl/kk` aborts on the first force evaluation:

```
RuntimeError: Expected all tensors to be on the same device, but found at
least two devices, cuda:0 and cpu!   (pair_matgl_kokkos.cpp:364)
```

**Cause.** `matgl/layers/_basis.py::spherical_bessel_smooth` builds two
constants without a device:

```python
n  = torch.arange(max_n).type(dtype=matgl.float_th)[None, :]   # line 361
dn = [torch.tensor(1.0)]                                       # line 374
```

In Python this is masked by matgl's global default device. Under LibTorch the
default device is CPU, so `n` lands on the host while `r` is on `cuda:0`. The
implication is that the exported TorchScript module had never been executed on
a GPU — i.e. the Kokkos path was never run end to end.

**Fix.** Derive the device from the input: `torch.arange(max_n, device=r.device)`
and `torch.tensor(1.0, device=r.device)`. Device-agnostic, and the Python path
is unchanged.

## 5. Ghost rows are fed to the model although no edge references them

Builds directly on #815's ghost-edge folding: since #815, every edge is
resolved to its owning local row (with explicit unit shifts), so ghost ROWS in
the node buffers are guaranteed-isolated nodes -- no incoming message, masked
out of the energy, exactly zero force. This item removes the wasted node work
that folding made removable; it is a performance follow-up, not a correctness
overlap.

**Performance, not correctness** — but it is most of the cost. #815 correctly
folds every edge back onto a local row (`atom->map(atom->tag[j])`) and carries
periodicity in `unit_shifts`, which is what makes message passing right. After
that fold, `i < nlocal` (the loop bound is `list->inum`, local only) and
`j_local < nlocal` by construction, so **no edge can reference a ghost row any
more**. Yet the tensors handed to the model are still sized `nall`:

```cpp
const int nall = nlocal + atom->nghost;
torch::Tensor positions      = torch::empty({nall, 3}, opts_real);
torch::Tensor atomic_numbers = torch::empty({nall}, opts_long);
torch::Tensor local_or_ghost = torch::empty({nall}, opts_bool);
```

Every one of the `nall − nlocal` ghost rows is therefore an **isolated node**:
it receives no messages, contributes no energy (it is masked out of the sum),
and gets zero force — but the model still computes embeddings, norms and
readout for it. The waste is the ghost fraction, which is set by cell size:

| cell | Nlocal | Nghost | nall/nlocal |
|---|---|---|---|
| 32 Å (1,248 atoms) | 1,248 | 2,502 | **3.00×** |
| 64 Å (9,984 atoms) | 9,984 | 8,174 | 1.82× |
| 96 Å (33,696 atoms) | 33,696 | 17,164 | 1.51× |

**Fix.** Size the model's inputs to `nlocal` in both styles. `local_or_ghost`
stays in the signature and becomes all-true. In the Kokkos variant this remains
a zero-copy view: LAMMPS keeps owned atoms in rows `[0, nlocal)` of `x`, so the
`from_blob` view simply narrows. Force scatter-back loops to `nlocal`; the ghost
entries were exactly zero (no edge touches them), so nothing is dropped.
`local_row_of_` stays sized to `nall` — it is the ghost→owner map that makes the
fold possible.

**Measured.** Results are unchanged and the step gets substantially cheaper.
4-atom Mo–S single point, before vs after:

| | PotEng (eV) | mean pressure (bar) |
|---|---|---|
| reference | −64.972801 | −88 496.4 |
| `matgl` after | −64.972801 | −88 496.396 |
| `matgl/kk` after | −64.972801 | −88 496.386 |

1,248-atom Li₃PO₄–TaCl₅, 1,000 steady-state NVT steps. All four legs were run
in ONE job on ONE GPU, interleaved over two rounds, with decks that differ only
where `pair_matgl` requires (`atom_modify map yes`, `newton on`). Same-job is
essential here: the `gnnp` legs vary by **25%** across nodes on this cluster
(23.0-28.19 ms/step over 8 measurements on 5 nodes), far more than the effect
being claimed, so a cross-job comparison could not have settled it:

| leg | ms/step | round spread |
|---|---|---|
| `pair_style gnnp` + `matgl-warp` (fp32) | 26.98 | 0.9% |
| `pair_style gnnp` + plain PyG (fp32) | 33.94 | 2.6% |
| `pair_style matgl/kk`, before this fix | 43.56 | 0.3% |
| **`pair_style matgl/kk`, after this fix** | **25.47** | 0.2% |

so this fix is worth **1.71×** on that cell. That figure is the same binary
before and after, in one job on one GPU, so node variation cannot touch it; the
same holds for the **1.33×** against `gnnp`+PyG, the backend the plugin actually
shares.

Against `gnnp`+`matgl-warp` the ordering is **not stable enough to state as a
ranking, and this PR does not claim one**. On the node above the plugin lands 6%
ahead (25.47 vs 26.98); on other nodes it lands behind. The sensitivity is
asymmetric: `gnnp`+`matgl-warp` is bound by Python-side dispatch and spans 25%
across nodes, while `pair_style matgl/kk` is a C++ style whose round-to-round
spread is 0.2%. At this cell size the two are close enough that which one "wins"
is a property of the node, not of the code.

The gain tracks the ghost fraction, so it is largest on small cells — and it is
smaller than the ghost ratio itself because only the NODE work shrinks, not the
edge work:

| cell | nall/nlocal | before | after | gain |
|---|---|---|---|---|
| 1,248 atoms (32 Å) | 3.00 | 43.56 | **25.47** | **1.71×** |
| 9,984 atoms (64 Å) | 1.82 | 241.06 | **165.68** | 1.46× |
| 33,696 atoms (96 Å) | 1.51 | 750.89 | **543.16** | 1.38× |

Against the same backend the plugin is now consistently ahead — `matgl/kk` vs
`gnnp`+PyG is 1.33× at 1,248 atoms and 1.35× at 9,984 (165.68 vs 224.33). The
two larger sizes are cross-job, so they carry the 25% node caveat; both gaps are
comfortably outside it, unlike the 6% one discussed above. It still trails
`gnnp`+`matgl-warp` at the larger sizes (165.68 vs 97.83 ms at 9,984, i.e. 1.69×
— also well outside the node spread) purely because that backend is unavailable
to the plugin,
and warp's advantage over PyG grows with size (1.24× at 1,248, 2.29× at 9,984).
Making the exporter support `use_warp=True` would be the natural follow-up, and
is out of scope here.

(Note that `pair_matgl` is PyG-only, so it cannot use the `matgl-warp`
backend that `pair_style gnnp` can — the numbers above are with the plugin on
the slower of the two matgl backends.)

## 6. `export_matgl_checkpoint.py` imports modules that no longer exist

`pair_matgl`'s `coeff()` shells out to this script when `pair_coeff` is given a
checkpoint directory, but the script imports the pre-4.0.3 module layout:

```python
import matgl.graph._compute_pyg as _cpyg          # now matgl.graph._compute
from matgl.ext._lammps import export_lammps_model # now matgl.ext.lammps
```

The first raises `ModuleNotFoundError` on 4.0.3, so the "point `pair_coeff` at
a checkpoint dir" path is dead. (`matgl.ext._lammps` does still import on 4.0.3
and still exports `export_lammps_model`, but the script never gets that far.)
Updated to `matgl.graph._compute` / `matgl.ext.lammps`; the
`create_line_graph_torch` shim is no longer needed because `_compute` exports it
directly.

## 7. Documentation gaps that block a first run

* **Kokkos requires `neigh half`.** `pair_matgl` errors out unless
  `newton on`, and LAMMPS refuses `newton on` together with the Kokkos default
  `neigh full`:

  ```
  ERROR: Must use 'newton off' with KOKKOS package option 'neigh full'
  (src/KOKKOS/kokkos.cpp:693)
  ```

  So every Kokkos run needs `-pk kokkos neigh half` (or `package kokkos neigh
  half` before `atom_style`). The README's run line omits this and fails as
  printed.

* **libtorch must be a CUDA build for the Kokkos variant.** The README says
  "LibTorch 2.2.x – 2.5.x (CXX11 ABI, CPU build)", but
  `pair_matgl_kokkos.cpp` selects `torch::Device(torch::kCUDA, gpu)` and wraps
  Kokkos device buffers as tensors without a copy. A CPU-only libtorch runs the
  model on the host. The CPU-build note applies to the CI job only.

* **Two CMake patches are needed for CUDA ≥ 12.9 toolkits.** libtorch's Caffe2
  config predates both, and each aborts the generate step. CUDA 12.9 removed
  the nvToolsExt shared library, so `FindCUDAToolkit` no longer defines
  `CUDA::nvToolsExt` while `Caffe2/public/cuda.cmake:186` still links it into
  `torch::nvtoolsext`; and on a system without MKL, Caffe2 leaves the literal
  `MKL_INCLUDE_DIR-NOTFOUND` inside torch's `INTERFACE_INCLUDE_DIRECTORIES`.
  Declaring `CUDA::nvToolsExt` as a header-only INTERFACE target (nvtx3 headers
  are still shipped) and pointing `MKL_INCLUDE_DIR` at an existing directory
  clears both. Added to the README as a troubleshooting note.

---

## Testing

* **Style registration** — `style_pair.h` contains both headers; `lmp -h`
  lists `matgl` and `matgl/kk`.
* **Single-point parity**, 4-atom Mo–S cell, against
  `python_reference.py` (matgl 4.0.3 / torch 2.7.1):

  | | PotEng (eV) |
  |---|---|
  | python reference | −64.9728012 |
  | `pair_style matgl` | −64.972801 |
  | `pair_style matgl/kk` | −64.972801 |

  Energies agree to printed precision on both styles. Pressures agree in
  both conventions once #825's CPU virial fix is applied (measured with it
  in place; this PR itself does not touch the virial).
* **1,248-atom NVT**, 300 warm-up + 1,000 timed steps, both styles, no NaN,
  temperature in band.
* **GPU execution** — `matgl/kk` reports `model on cuda` and completes
  1,300 steps after fix #4 (before it aborted at step 0).

## Notes on CI

The existing job cannot catch #2 or #4: it diffs energy only, and
GitHub-hosted runners have no GPU. Two cheap additions would close both gaps:

1. the **virial/pressure** gap is already being closed by #825, which adds a
   finite-difference pressure validation to CI — once it lands, #3's `P = −σ`
   labeling makes that check unambiguous to read;
2. run `spherical_bessel_smooth` once under `torch.set_default_device('cpu')`
   with a CUDA input in a unit test — this reproduces #4 without a GPU-enabled
   LAMMPS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


